### PR TITLE
docs: standard JavaScript APIs

### DIFF
--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -33,6 +33,11 @@ Hello universe!
 
 ## Platform APIs
 
+### Standard JavaScript APIs
+
+Zinnia provides all standard JavaScript APIs, you can find the full list in
+[MDN web docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects).
+
 ### console
 
 Zinnia implements most of the `console` Web APIs like `console.log`. You can


### PR DESCRIPTION
It turns out we support all standard JS APIs, including things like `Date` and `Intl`.

Example code:

```js
console.log('NOW:', Date.now());
console.log('new Date:', new Date());

console.log(encodeURI('hello world'))

const regionNamesInEnglish = new Intl.DisplayNames(['en'], { type: 'region' });
const regionNamesInTraditionalChinese = new Intl.DisplayNames(['zh-Hant'], { type: 'region' });

console.log(regionNamesInEnglish.of('US'));
console.log(regionNamesInTraditionalChinese.of('US'));
```

Example output:

```
❯ zinnia run jsapis.js
NOW: 1675861800870
new Date: 2023-02-08T13:10:00.870Z
hello%20world
United States
美國
```

