### PR TITLE
feat: add `deno_web` APIs like `setTimeout`

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,2 +1,3 @@
 editorconfig: true
 proseWrap: always
+trailingComma: all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4199,6 +4199,8 @@ dependencies = [
 name = "zinnia_runtime"
 version = "0.0.0"
 dependencies = [
+ "assert_fs",
  "deno_runtime",
+ "pretty_assertions",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,16 @@ repository = "https://github.com/filecoin-station/zinnia"
 
 [workspace.dependencies]
 tokio = { version = "1.24.1", features = ["fs", "rt", "macros"] }
+assert_fs = "1.0.10"
+pretty_assertions = "1.3.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# workspace-local
+zinnia_runtime = { path = "./runtime" }
 
 [profile.release]
 codegen-units = 1
 incremental = true
 lto = true
 opt-level = 3
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,12 +18,12 @@ doc = false
 [dependencies]
 clap = { version = "4.1.4", features = ["derive"] }
 tokio = { workspace = true }
-zinnia_runtime = { path = "../runtime" }
+zinnia_runtime = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.8"
-assert_fs = "1.0.10"
-pretty_assertions = "1.3.0"
+assert_fs = { workspace = true }
+pretty_assertions = { workspace = true }
 
 [package.metadata.winres]
 # This section defines the metadata that appears in the deno.exe PE header.

--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -38,12 +38,144 @@ Hello universe!
 Zinnia provides all standard JavaScript APIs, you can find the full list in
 [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects).
 
-### console
+### Web APIs
+
+The following entities are defined in the global scope (`globalThis`).
+
+#### Console Standard
 
 Zinnia implements most of the `console` Web APIs like `console.log`. You can
 find the full list of supported methods in
 [Deno docs](https://deno.land/api@v1.30.3?s=Console) and more details about
 individual methods in
-[MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/console.)
+[MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/console)
 
-### More APIs are coming
+- [console](https://developer.mozilla.org/en-US/docs/Web/API/console)
+
+#### DOM Standard
+
+- [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
+- [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+- [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent)
+- [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event)
+- [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
+
+#### Encoding Standard
+
+- [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder)
+- [TextEncoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder)
+- [TextDecoderStream](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoderStream)
+- [TextEncoderStream](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoderStream)
+
+#### File API
+
+- [Blob](https://developer.mozilla.org/en-US/docs/Web/API/blob)
+- [File](https://developer.mozilla.org/en-US/docs/Web/API/File)
+- [FileReader](https://developer.mozilla.org/en-US/docs/Web/API/FileReader)
+
+#### HTML Standard
+
+- [ErrorEvent](https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent)
+- [MessageChannel](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel)
+- [MessageEvent](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent)
+- [MessagePort](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort)
+- [PromiseRejectionEvent](https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent)
+- [atob](https://developer.mozilla.org/en-US/docs/Web/API/atob)
+- [btoa](https://developer.mozilla.org/en-US/docs/Web/API/btoa)
+- [clearInterval](https://developer.mozilla.org/en-US/docs/Web/API/clearInterval)
+- [clearTimeout](https://developer.mozilla.org/en-US/docs/Web/API/clearTimeout)
+- [reportError](https://developer.mozilla.org/en-US/docs/Web/API/reportError)
+- [setInterval](https://developer.mozilla.org/en-US/docs/Web/API/setInterval)
+- [setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout)
+- [structuredClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone)
+
+#### Performance & User Timing
+
+- [Performance](https://developer.mozilla.org/en-US/docs/Web/API/Performance)
+- [PerformanceEntry](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry)
+- [PerformanceMark](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMark)
+- [PerformanceMeasure](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMeasure)
+- [performance](https://developer.mozilla.org/en-US/docs/Web/API/performance)
+
+#### Streams Standard
+
+- [ByteLengthQueuingStrategy](https://developer.mozilla.org/en-US/docs/Web/API/ByteLengthQueuingStrategy)
+- [CompressionStream](https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream)
+- [CountQueuingStrategy](https://developer.mozilla.org/en-US/docs/Web/API/CountQueuingStrategy)
+- [DecompressionStream](https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream)
+- [ReadableByteStreamController](https://developer.mozilla.org/en-US/docs/Web/API/ReadableByteStreamController)
+- [ReadableStreamBYOBReader](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBReader)
+- [ReadableStreamBYOBRequest](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBRequest)
+- [ReadableStreamDefaultController](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController)
+- [ReadableStreamDefaultReader](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader)
+- [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
+- [TransformStreamDefaultController](https://developer.mozilla.org/en-US/docs/Web/API/TransformStreamDefaultController)
+- [TransformStream](https://developer.mozilla.org/en-US/docs/Web/API/TransformStream)
+- [WritableStreamDefaultController](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultController)
+- [WritableStreamDefaultWriter](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter)
+- [WritableStream](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream)
+
+#### URL Standard
+
+- [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL)
+- [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
+- [URLPattern](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern)
+
+#### WebSockets Standard (partial support)
+
+- [CloseEvent](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent)
+
+#### Web IDL Standard
+
+- [DOMException](https://developer.mozilla.org/en-US/docs/Web/API/DOMException)
+
+#### XMLHttpRequest Standard (partial support)
+
+- [ProgressEvent](https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent)
+
+<!--
+UNSUPPORTED
+-->
+
+## Unsupported Web APIs
+
+The following Web APIs are not supported yet.
+
+#### Fetch Standard
+
+Tracking issue: https://github.com/filecoin-station/zinnia/issues/25
+
+- [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers)
+- [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request)
+- [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response)
+- [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch)
+
+#### Service Workers & Web Workers
+
+Tracking issue: n/a
+
+- [CacheStorage](https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage)
+- [Cache](https://developer.mozilla.org/en-US/docs/Web/API/Cache)
+- [Worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker)
+- [caches](https://developer.mozilla.org/en-US/docs/Web/API/caches)
+
+#### Web Cryptography API
+
+Tracking issue: https://github.com/filecoin-station/zinnia/issues/33
+
+- [CryptoKey](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey)
+- [Crypto](https://developer.mozilla.org/en-US/docs/Web/API/Crypto)
+- [SubtleCrypto](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto)
+- [crypto](https://developer.mozilla.org/en-US/docs/Web/API/crypto)
+
+#### WebSockets Standard
+
+Tracking issue: n/a
+
+- [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
+
+#### XMLHttpRequest Standard
+
+Tracking issue: n/a
+
+- [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData)

--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -129,10 +129,6 @@ individual methods in
 
 - [DOMException](https://developer.mozilla.org/en-US/docs/Web/API/DOMException)
 
-#### XMLHttpRequest Standard (partial support)
-
-- [ProgressEvent](https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent)
-
 <!--
 UNSUPPORTED
 -->
@@ -145,7 +141,9 @@ The following Web APIs are not supported yet.
 
 Tracking issue: https://github.com/filecoin-station/zinnia/issues/25
 
+- [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData)
 - [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers)
+- [ProgressEvent](https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent)
 - [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request)
 - [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response)
 - [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch)
@@ -174,8 +172,6 @@ Tracking issue: n/a
 
 - [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
 
-#### XMLHttpRequest Standard
+#### Other
 
-Tracking issue: n/a
-
-- [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData)
+- `XMLHttpRequest` Standard

--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -67,12 +67,6 @@ individual methods in
 - [TextDecoderStream](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoderStream)
 - [TextEncoderStream](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoderStream)
 
-#### File API
-
-- [Blob](https://developer.mozilla.org/en-US/docs/Web/API/blob)
-- [File](https://developer.mozilla.org/en-US/docs/Web/API/File)
-- [FileReader](https://developer.mozilla.org/en-US/docs/Web/API/FileReader)
-
 #### HTML Standard
 
 - [ErrorEvent](https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent)
@@ -147,6 +141,14 @@ Tracking issue: https://github.com/filecoin-station/zinnia/issues/25
 - [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request)
 - [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response)
 - [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch)
+
+#### File API
+
+Tracking issue: n/a
+
+- [Blob](https://developer.mozilla.org/en-US/docs/Web/API/blob)
+- [File](https://developer.mozilla.org/en-US/docs/Web/API/File)
+- [FileReader](https://developer.mozilla.org/en-US/docs/Web/API/FileReader)
 
 #### Service Workers & Web Workers
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,7 +16,6 @@ path = "lib.rs"
 deno_runtime = "0.97.0"
 tokio = { workspace = true, features = ["fs"] }
 
-# [dev-dependencies]
-# assert_cmd = "2.0.8"
-# assert_fs = "1.0.10"
-# pretty_assertions = "1.3.0"
+[dev-dependencies]
+assert_fs = { workspace = true }
+pretty_assertions = { workspace = true }

--- a/runtime/js/06_util.js
+++ b/runtime/js/06_util.js
@@ -1,0 +1,86 @@
+// ZINNIA VERSION: Copyright 2023 Protocol Labs. All rights reserved. MIT OR Apache-2.0 license.
+// ORIGINAL WORK: Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// https://github.com/denoland/deno/blob/f3fb8ee18826e66d3896ea864d2bedaed6c79308/runtime/js/06_util.js
+"use strict";
+
+((window) => {
+  const { Promise, SafeArrayIterator } = window.__bootstrap.primordials;
+  let logDebug = false;
+  let logSource = "JS";
+
+  function setLogDebug(debug, source) {
+    logDebug = debug;
+    if (source) {
+      logSource = source;
+    }
+  }
+
+  function log(...args) {
+    if (logDebug) {
+      // if we destructure `console` off `globalThis` too early, we don't bind to
+      // the right console, therefore we don't log anything out.
+      globalThis.console.log(
+        `DEBUG ${logSource} -`,
+        ...new SafeArrayIterator(args),
+      );
+    }
+  }
+
+  function createResolvable() {
+    let resolve;
+    let reject;
+    const promise = new Promise((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    promise.resolve = resolve;
+    promise.reject = reject;
+    return promise;
+  }
+
+  function writable(value) {
+    return {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    };
+  }
+
+  function nonEnumerable(value) {
+    return {
+      value,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    };
+  }
+
+  function readOnly(value) {
+    return {
+      value,
+      enumerable: true,
+      writable: false,
+      configurable: true,
+    };
+  }
+
+  function getterOnly(getter) {
+    return {
+      get: getter,
+      set() {},
+      enumerable: true,
+      configurable: true,
+    };
+  }
+
+  window.__bootstrap.util = {
+    log,
+    setLogDebug,
+    createResolvable,
+    writable,
+    nonEnumerable,
+    readOnly,
+    getterOnly,
+  };
+})(this);

--- a/runtime/js/98_global_scope.js
+++ b/runtime/js/98_global_scope.js
@@ -7,23 +7,128 @@
 ((window) => {
   const core = Deno.core;
 
+  const util = window.__bootstrap.util;
+  const event = window.__bootstrap.event;
+  const eventTarget = window.__bootstrap.eventTarget;
+  const timers = window.__bootstrap.timers;
+  const base64 = window.__bootstrap.base64;
+  const encoding = window.__bootstrap.encoding;
   const Console = window.__bootstrap.console.Console;
-
-  // from Deno's window.__bootstrap.util
-  function nonEnumerable(value) {
-    return {
-      value,
-      writable: true,
-      enumerable: false,
-      configurable: true,
-    };
-  }
+  const compression = window.__bootstrap.compression;
+  const performance = window.__bootstrap.performance;
+  const url = window.__bootstrap.url;
+  const urlPattern = window.__bootstrap.urlPattern;
+  const streams = window.__bootstrap.streams;
+  const fileReader = window.__bootstrap.fileReader;
+  const file = window.__bootstrap.file;
+  const messagePort = window.__bootstrap.messagePort;
+  const webidl = window.__bootstrap.webidl;
+  const domException = window.__bootstrap.domException;
+  const abortSignal = window.__bootstrap.abortSignal;
 
   // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope
   const windowOrWorkerGlobalScope = {
-    console: nonEnumerable(
-      new Console((msg, level) => core.print(msg, level > 1))
+    AbortController: util.nonEnumerable(abortSignal.AbortController),
+    AbortSignal: util.nonEnumerable(abortSignal.AbortSignal),
+    Blob: util.nonEnumerable(file.Blob),
+    ByteLengthQueuingStrategy: util.nonEnumerable(
+      streams.ByteLengthQueuingStrategy,
     ),
+    CloseEvent: util.nonEnumerable(event.CloseEvent),
+    CompressionStream: util.nonEnumerable(compression.CompressionStream),
+    CountQueuingStrategy: util.nonEnumerable(streams.CountQueuingStrategy),
+    // TODO https://github.com/filecoin-station/zinnia/issues/33
+    // CryptoKey: util.nonEnumerable(crypto.CryptoKey),
+    CustomEvent: util.nonEnumerable(event.CustomEvent),
+    DecompressionStream: util.nonEnumerable(compression.DecompressionStream),
+    DOMException: util.nonEnumerable(domException.DOMException),
+    ErrorEvent: util.nonEnumerable(event.ErrorEvent),
+    Event: util.nonEnumerable(event.Event),
+    EventTarget: util.nonEnumerable(eventTarget.EventTarget),
+    File: util.nonEnumerable(file.File),
+    FileReader: util.nonEnumerable(fileReader.FileReader),
+    // Not supported API from XMLHttpRequest
+    // FormData: util.nonEnumerable(formData.FormData),
+    // TODO:  https://github.com/filecoin-station/zinnia/issues/25
+    // Headers: util.nonEnumerable(headers.Headers),
+    MessageEvent: util.nonEnumerable(event.MessageEvent),
+    Performance: util.nonEnumerable(performance.Performance),
+    PerformanceEntry: util.nonEnumerable(performance.PerformanceEntry),
+    PerformanceMark: util.nonEnumerable(performance.PerformanceMark),
+    PerformanceMeasure: util.nonEnumerable(performance.PerformanceMeasure),
+    PromiseRejectionEvent: util.nonEnumerable(event.PromiseRejectionEvent),
+    ProgressEvent: util.nonEnumerable(event.ProgressEvent),
+    ReadableStream: util.nonEnumerable(streams.ReadableStream),
+    ReadableStreamDefaultReader: util.nonEnumerable(
+      streams.ReadableStreamDefaultReader,
+    ),
+    // TODO:  https://github.com/filecoin-station/zinnia/issues/25
+    // Request: util.nonEnumerable(fetch.Request),
+    // Response: util.nonEnumerable(fetch.Response),
+    TextDecoder: util.nonEnumerable(encoding.TextDecoder),
+    TextEncoder: util.nonEnumerable(encoding.TextEncoder),
+    TextDecoderStream: util.nonEnumerable(encoding.TextDecoderStream),
+    TextEncoderStream: util.nonEnumerable(encoding.TextEncoderStream),
+    TransformStream: util.nonEnumerable(streams.TransformStream),
+    URL: util.nonEnumerable(url.URL),
+    URLPattern: util.nonEnumerable(urlPattern.URLPattern),
+    URLSearchParams: util.nonEnumerable(url.URLSearchParams),
+    // TODO(?): WebSocket Standard
+    // WebSocket: util.nonEnumerable(webSocket.WebSocket),
+    MessageChannel: util.nonEnumerable(messagePort.MessageChannel),
+    MessagePort: util.nonEnumerable(messagePort.MessagePort),
+    // TODO(?): Service & Web Workers
+    // Worker: util.nonEnumerable(worker.Worker),
+    WritableStream: util.nonEnumerable(streams.WritableStream),
+    WritableStreamDefaultWriter: util.nonEnumerable(
+      streams.WritableStreamDefaultWriter,
+    ),
+    WritableStreamDefaultController: util.nonEnumerable(
+      streams.WritableStreamDefaultController,
+    ),
+    ReadableByteStreamController: util.nonEnumerable(
+      streams.ReadableByteStreamController,
+    ),
+    ReadableStreamBYOBReader: util.nonEnumerable(
+      streams.ReadableStreamBYOBReader,
+    ),
+    ReadableStreamBYOBRequest: util.nonEnumerable(
+      streams.ReadableStreamBYOBRequest,
+    ),
+    ReadableStreamDefaultController: util.nonEnumerable(
+      streams.ReadableStreamDefaultController,
+    ),
+    TransformStreamDefaultController: util.nonEnumerable(
+      streams.TransformStreamDefaultController,
+    ),
+    atob: util.writable(base64.atob),
+    btoa: util.writable(base64.btoa),
+    clearInterval: util.writable(timers.clearInterval),
+    clearTimeout: util.writable(timers.clearTimeout),
+    // TODO(?): Service & Web Workers
+    // caches: {
+    //   enumerable: true,
+    //   configurable: true,
+    //   get: caches.cacheStorage,
+    // },
+    // CacheStorage: util.nonEnumerable(caches.CacheStorage),
+    // Cache: util.nonEnumerable(caches.Cache),
+    console: util.nonEnumerable(
+      new Console((msg, level) => core.print(msg, level > 1)),
+    ),
+    // TODO: https://github.com/filecoin-station/zinnia/issues/33
+    // crypto: util.readOnly(crypto.crypto),
+    // Crypto: util.nonEnumerable(crypto.Crypto),
+    // SubtleCrypto: util.nonEnumerable(crypto.SubtleCrypto),
+    // TODO:  https://github.com/filecoin-station/zinnia/issues/25
+    // fetch: util.writable(fetch.fetch),
+    performance: util.writable(performance.performance),
+    reportError: util.writable(event.reportError),
+    setInterval: util.writable(timers.setInterval),
+    setTimeout: util.writable(timers.setTimeout),
+    structuredClone: util.writable(messagePort.structuredClone),
+    // Branding as a WebIDL object
+    [webidl.brand]: util.nonEnumerable(webidl.brand),
   };
 
   window.__bootstrap.globalScope = {

--- a/runtime/js/98_global_scope.js
+++ b/runtime/js/98_global_scope.js
@@ -47,9 +47,8 @@
     EventTarget: util.nonEnumerable(eventTarget.EventTarget),
     File: util.nonEnumerable(file.File),
     FileReader: util.nonEnumerable(fileReader.FileReader),
-    // Not supported API from XMLHttpRequest
-    // FormData: util.nonEnumerable(formData.FormData),
     // TODO:  https://github.com/filecoin-station/zinnia/issues/25
+    // FormData: util.nonEnumerable(formData.FormData),
     // Headers: util.nonEnumerable(headers.Headers),
     MessageEvent: util.nonEnumerable(event.MessageEvent),
     Performance: util.nonEnumerable(performance.Performance),
@@ -57,7 +56,8 @@
     PerformanceMark: util.nonEnumerable(performance.PerformanceMark),
     PerformanceMeasure: util.nonEnumerable(performance.PerformanceMeasure),
     PromiseRejectionEvent: util.nonEnumerable(event.PromiseRejectionEvent),
-    ProgressEvent: util.nonEnumerable(event.ProgressEvent),
+    // TODO:  https://github.com/filecoin-station/zinnia/issues/25
+    // ProgressEvent: util.nonEnumerable(event.ProgressEvent),
     ReadableStream: util.nonEnumerable(streams.ReadableStream),
     ReadableStreamDefaultReader: util.nonEnumerable(
       streams.ReadableStreamDefaultReader,

--- a/runtime/js/98_global_scope.js
+++ b/runtime/js/98_global_scope.js
@@ -31,7 +31,8 @@
   const windowOrWorkerGlobalScope = {
     AbortController: util.nonEnumerable(abortSignal.AbortController),
     AbortSignal: util.nonEnumerable(abortSignal.AbortSignal),
-    Blob: util.nonEnumerable(file.Blob),
+    // Intentionally disabled until we need this.
+    // Blob: util.nonEnumerable(file.Blob),
     ByteLengthQueuingStrategy: util.nonEnumerable(
       streams.ByteLengthQueuingStrategy,
     ),
@@ -46,8 +47,9 @@
     ErrorEvent: util.nonEnumerable(event.ErrorEvent),
     Event: util.nonEnumerable(event.Event),
     EventTarget: util.nonEnumerable(eventTarget.EventTarget),
-    File: util.nonEnumerable(file.File),
-    FileReader: util.nonEnumerable(fileReader.FileReader),
+    // Intentionally disabled until we need this.
+    // File: util.nonEnumerable(file.File),
+    // FileReader: util.nonEnumerable(fileReader.FileReader),
     // TODO:  https://github.com/filecoin-station/zinnia/issues/25
     // FormData: util.nonEnumerable(formData.FormData),
     // Headers: util.nonEnumerable(headers.Headers),

--- a/runtime/js/98_global_scope.js
+++ b/runtime/js/98_global_scope.js
@@ -25,6 +25,7 @@
   const webidl = window.__bootstrap.webidl;
   const domException = window.__bootstrap.domException;
   const abortSignal = window.__bootstrap.abortSignal;
+  const globalInterfaces = window.__bootstrap.globalInterfaces;
 
   // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope
   const windowOrWorkerGlobalScope = {
@@ -131,7 +132,24 @@
     [webidl.brand]: util.nonEnumerable(webidl.brand),
   };
 
+  const mainRuntimeGlobalProperties = {
+    // Location: location.locationConstructorDescriptor,
+    // location: location.locationDescriptor,
+    Window: globalInterfaces.windowConstructorDescriptor,
+    window: util.getterOnly(() => globalThis),
+    self: util.getterOnly(() => globalThis),
+    // Navigator: util.nonEnumerable(Navigator),
+    // navigator: util.getterOnly(() => navigator),
+    // alert: util.writable(prompt.alert),
+    // confirm: util.writable(prompt.confirm),
+    // prompt: util.writable(prompt.prompt),
+    // localStorage: util.getterOnly(webStorage.localStorage),
+    // sessionStorage: util.getterOnly(webStorage.sessionStorage),
+    // Storage: util.nonEnumerable(webStorage.Storage),
+  };
+
   window.__bootstrap.globalScope = {
     windowOrWorkerGlobalScope,
+    mainRuntimeGlobalProperties,
   };
 })(this);

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -19,11 +19,14 @@ delete Intl.v8BreakIterator;
     ErrorPrototype,
     ObjectDefineProperties,
     ObjectPrototypeIsPrototypeOf,
+    ObjectSetPrototypeOf,
   } = window.__bootstrap.primordials;
+  const eventTarget = window.__bootstrap.eventTarget;
   const colors = window.__bootstrap.colors;
   const inspectArgs = window.__bootstrap.console.inspectArgs;
   const quoteString = window.__bootstrap.console.quoteString;
-  const { windowOrWorkerGlobalScope } = window.__bootstrap.globalScope;
+  const { windowOrWorkerGlobalScope, mainRuntimeGlobalProperties } =
+    window.__bootstrap.globalScope;
 
   function formatException(error) {
     if (ObjectPrototypeIsPrototypeOf(ErrorPrototype, error)) {
@@ -64,11 +67,15 @@ delete Intl.v8BreakIterator;
     hasBootstrapped = true;
 
     ObjectDefineProperties(globalThis, windowOrWorkerGlobalScope);
+    ObjectDefineProperties(globalThis, mainRuntimeGlobalProperties);
+    ObjectSetPrototypeOf(globalThis, Window.prototype);
 
     if (runtimeOptions.inspectFlag) {
       const consoleFromDeno = globalThis.console;
       wrapConsole(consoleFromDeno, consoleFromV8);
     }
+
+    eventTarget.setEventTargetData(globalThis);
 
     runtimeStart(runtimeOptions);
 

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -4,3 +4,5 @@ pub use deno_runtime::fmt_errors;
 
 pub mod runtime;
 pub use runtime::*;
+
+pub use deno_core::resolve_path;

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -57,7 +57,12 @@ struct ZinniaPermissions;
 
 impl TimersPermission for ZinniaPermissions {
   fn allow_hrtime(&mut self) -> bool {
-    true
+    // TODO: should we allow APIs depending in high-resultion time?
+    // Quoting https://deno.land/manual@v1.30.3/basics/permissions#permissions-list
+    //   --allow-hrtime
+    //   Allow high-resolution time measurement. High-resolution time can be used in timing attacks
+    //   and fingerprinting.
+    false
   }
   fn check_unstable(
     &self,

--- a/runtime/tests/integration/globals_tests.rs
+++ b/runtime/tests/integration/globals_tests.rs
@@ -1,0 +1,45 @@
+use assert_fs::prelude::*;
+use zinnia_runtime::resolve_path;
+use zinnia_runtime::run_js_module;
+
+#[tokio::test]
+async fn has_global_window() -> Result<(), Box<dyn std::error::Error>> {
+  let mod_js = assert_fs::NamedTempFile::new("global_window_test.js")?;
+  mod_js.write_str(
+    r#"
+if (typeof window !== 'object')
+    throw new Error(`Expected \`window\` to have type "object" but found "${typeof window}"`);
+if (window != globalThis)
+    throw new Error('Expected `window` to be `globalThis`');
+"#,
+  )?;
+
+  run_js_module(
+    &resolve_path(&mod_js.path().to_string_lossy())?,
+    &Default::default(),
+  )
+  .await?;
+
+  Ok(())
+}
+
+#[tokio::test]
+async fn has_global_self() -> Result<(), Box<dyn std::error::Error>> {
+  let mod_js = assert_fs::NamedTempFile::new("global_self_test.js")?;
+  mod_js.write_str(
+    r#"
+if (typeof self !== 'object')
+    throw new Error(`Expected \`self\` to have type "object" but found "${typeof self}"`);
+if (self != globalThis)
+    throw new Error('Expected `self` to be `globalThis`');
+"#,
+  )?;
+
+  run_js_module(
+    &resolve_path(&mod_js.path().to_string_lossy())?,
+    &Default::default(),
+  )
+  .await?;
+
+  Ok(())
+}

--- a/runtime/tests/integration/mod.rs
+++ b/runtime/tests/integration/mod.rs
@@ -1,0 +1,10 @@
+// ZINNIA VERSION: Copyright 2023 Protocol Labs. All rights reserved. MIT OR Apache-2.0 license.
+// ORIGINAL WORK: Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// https://github.com/denoland/deno/blob/19543ffec300390f20b577b29d92a58540aaef70/cli/tests/integration/mod.rs
+
+// These files have `_tests.rs` suffix to make it easier to tell which file is
+// the test (ex. `lint_tests.rs`) and which is the implementation (ex. `lint.rs`)
+// when both are open, especially for two tabs in VS Code
+
+#[path = "timers_tests.rs"]
+mod timers;

--- a/runtime/tests/integration/mod.rs
+++ b/runtime/tests/integration/mod.rs
@@ -8,3 +8,6 @@
 
 #[path = "timers_tests.rs"]
 mod timers;
+
+#[path = "globals_tests.rs"]
+mod globals;

--- a/runtime/tests/integration/timers_tests.rs
+++ b/runtime/tests/integration/timers_tests.rs
@@ -1,0 +1,30 @@
+use std::time::Instant;
+
+use assert_fs::prelude::*;
+use zinnia_runtime::resolve_path;
+use zinnia_runtime::run_js_module;
+
+#[tokio::test]
+async fn set_timeout_works() -> Result<(), Box<dyn std::error::Error>> {
+  let mod_js = assert_fs::NamedTempFile::new("timers_tests.js")?;
+  mod_js.write_str(
+    r#"
+setTimeout(() => {}, 50);
+"#,
+  )?;
+
+  let now = Instant::now();
+  run_js_module(
+    &resolve_path(&mod_js.path().to_string_lossy())?,
+    &Default::default(),
+  )
+  .await?;
+  let elapsed = now.elapsed().as_millis();
+
+  assert!(
+    elapsed > 40 && elapsed < 100,
+    "setTimeout(50) should take between 40 to 100 ms to execute, but took {elapsed} ms instead",
+  );
+
+  Ok(())
+}

--- a/runtime/tests/runtime_integration_tests.rs
+++ b/runtime/tests/runtime_integration_tests.rs
@@ -1,0 +1,8 @@
+// ZINNIA VERSION: Copyright 2023 Protocol Labs. All rights reserved. MIT OR Apache-2.0 license.
+// ORIGINAL WORK: Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// https://github.com/denoland/deno/blob/19543ffec300390f20b577b29d92a58540aaef70/cli/tests/integration_tests.rs
+
+// The tests exist in a sub folder instead of as separate files in
+// this directory so that cargo doesn't compile each file as a new crate.
+
+mod integration;


### PR DESCRIPTION
Add JS APIs from `deno_web` crate.

Most notably:

- Events and `AbortController`
- `TextEncoder` and `TextDecoder` (will be needed for WASM)
- `File`, `FileReader` and `Blob`
- `MessageChannel`, `structuredClone` and friends
- `atob` and `atoa` (will be needed for WASM)
- `setTimeout`, `setInterval`, and friends
- `Performance` APIs
- Streams (`ReadableStream`, `WritableStream`, etc.)
- `URL` and friends

See #7 
