### PR TITLE
feat!: remove Minimal Supported Rust Version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,25 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get MSRV for ${{ matrix.crate }}
-        id: parse-msrv
-        run: |
-          RUST_VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "${{ matrix.crate }}") | .rust_version')
-          echo "version=${RUST_VERSION}" >> $GITHUB_OUTPUT
-
-      - name: Install Rust ${{ steps.parse-msrv.outputs.version }} for MSRV check
-        uses: dtolnay/rust-toolchain@9cd00a88a73addc8617065438eff914dd08d0955 # v1
-        with:
-          toolchain: ${{ steps.parse-msrv.outputs.version }}
-
-      - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
-        with:
-          shared-key: msrv-${{ matrix.crate }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Check if ${{ matrix.crate }} compiles on MSRV (Rust ${{ steps.parse-msrv.outputs.version }})
-        run: cargo +${{ steps.parse-msrv.outputs.version }} build --package ${{ matrix.crate }} --all-features
-
       - uses: dtolnay/rust-toolchain@9cd00a88a73addc8617065438eff914dd08d0955 # v1
         with:
           toolchain: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ members = [
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.66.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs"]
 repository = "https://github.com/filecoin-station/zinnia"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,7 +3,6 @@ name = "zinnia"
 version = "0.0.2"
 authors.workspace = true
 default-run = "zinnia"
-rust-version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,6 @@
 name = "zinnia_runtime"
 version = "0.0.0"
 authors.workspace = true
-rust-version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Remove Minimal Supported Rust Version from our `Cargo.toml` files and remove the CI build steps checking the conformance.

At this early stage of the project, we don't need to support older versions of Rust. Having faster CI builds is more important to allow us to iterate faster.
