### PR TITLE
ci: improve caching of build artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
           # save-if: ${{ github.ref == 'refs/heads/main' }}
 
 
-      - run: cargo build --workspace --all-features --target=${{ matrix.target }}
+      - run: cargo build --workspace --all-features --all-targets --target=${{ matrix.target }}
 
   test:
     name: Test ${{ matrix.crate }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
           save-if: false
 
       - name: Run all tests
-        run: cargo test --package ${{ matrix.crate }} --all-features
+        run: cargo test --package ${{ matrix.crate }} --all-features --target=${{ matrix.target }}
 
       # - name: Check if we compile without any features activated
       #   run: cargo build --package ${{ matrix.crate }} --no-default-features


### PR DESCRIPTION
- ci: add `--target` to `cargo test`
- ci: build all targets (bins, libs, tests, etc.)
