### PR TITLE
chore: set zinnia_runtime version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ assert_fs = "1.0.10"
 pretty_assertions = "1.3.0"
 
 # workspace-local
-zinnia_runtime = { path = "./runtime" }
+zinnia_runtime = { version = "0.0.3", path = "./runtime" }
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
Before this change, we were not able to publish zinnia CLI crate.

```
❯ cargo publish -p zinnia
    Updating crates.io index
error: all dependencies must have a version specified when publishing.
dependency `zinnia_runtime` does not specify a version
Note: The published dependency will use the version from crates.io,
the `path` specification will be removed from the dependency declaration.
```
