### PR TITLE
ci: test all crates together

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,15 +45,13 @@ jobs:
       - run: cargo build --workspace --all-features --all-targets --target=${{ matrix.target }}
 
   test:
-    name: Test ${{ matrix.crate }}
+    name: Test all crates
     runs-on: ubuntu-latest
     needs:
-      - gather_published_crates
       - build
     strategy:
       fail-fast: false
       matrix:
-        crate: ${{ fromJSON(needs.gather_published_crates.outputs.members) }}
         include:
           # Should we run the tests on Windows and macOS too?
           # - target: "x86_64-apple-darwin"
@@ -75,7 +73,7 @@ jobs:
           save-if: false
 
       - name: Run all tests
-        run: cargo test --package ${{ matrix.crate }} --all-features --target=${{ matrix.target }}
+        run: cargo test --all-features --target=${{ matrix.target }}
 
       # - name: Check if we compile without any features activated
       #   run: cargo build --package ${{ matrix.crate }} --no-default-features
@@ -146,18 +144,6 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt -- --check
-
-  gather_published_crates:
-    runs-on: ubuntu-latest
-    outputs:
-      members: ${{ steps.cargo-metadata.outputs.members }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - id: cargo-metadata
-        run: |
-          WORKSPACE_MEMBERS=$(cargo metadata --format-version=1 --no-deps | jq -c '.packages | .[] | select(.publish == null) | .name' | jq -s '.' | jq -c '.')
-          echo "members=${WORKSPACE_MEMBERS}" >> $GITHUB_OUTPUT
 
   validate_pr_title:
     name: Validate PR title


### PR DESCRIPTION
When testing crates independently, we are not able to build `zinnia_libp2p`
(see #48):

```
   Compiling v8 v0.60.1
error: could not find native static library `rusty_v8`, perhaps an -L flag is missing?
error: could not compile `v8` due to previous error
```

In this change, I am reworking the test matrix to test all crates together. Cargo is already doing a great job in running tests in parallel.

It takes longer to build our tests than to execute them, so this change may speed up our CI builds too.
