### PR TITLE
docs: create single tag when releasing

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -20,7 +20,7 @@ documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
 1. Create the new release, replace `0.1.2` with the NEW version number:
 
    ```sh
-   $ cargo release --workspace --sign-tag --execute 0.1.2
+   $ cargo release --workspace --sign-tag --tag-prefix "" --execute 0.1.2
    ```
 
 1. Continue on GitHub to create a new Release:


### PR DESCRIPTION
Update release instructions and add `--tag-prefix ""` argument to `cargo release`. This way we create a single tag shared by all crates (e.g. `v0.1.0`) instead of per-crate tags like `zinnia-v0.1.0`.

