### PR TITLE
docs: fix libp2p example code

### DIFF
--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -195,7 +195,7 @@ const response = await Zinnia.requestProtocol(
   new Uint8Array(32),
 );
 
-for (const chunk of response) {
+for await (const chunk of response) {
   console.log(chunk);
 }
 ```


### PR DESCRIPTION
The response stream is async-iterable, we need to use `for async`.
