### PR TITLE
feat: support libp2p RSA public keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,6 +2770,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.8.5",
+ "ring",
  "rw-stream-sink",
  "sec1",
  "serde",

--- a/ext/libp2p/Cargo.toml
+++ b/ext/libp2p/Cargo.toml
@@ -43,7 +43,7 @@ features = [
     # "relay",
     # "rendezvous",
     "request-response",
-    # "rsa",
+    "rsa",
     # "secp256k1",
     "serde",
     "tcp",


### PR DESCRIPTION
Some older go-libp2p nodes are still using RSA public keys. This PR enables
Zinnia to connect to such nodes too.
