### PR TITLE
feat: fix compat with Rust, enable Ping + Identify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6510,6 +6510,7 @@ dependencies = [
  "env_logger",
  "libp2p",
  "log",
+ "rand 0.8.5",
  "smallvec",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,6 +2747,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-dns",
  "libp2p-gossipsub",
+ "libp2p-identify",
  "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
@@ -2847,6 +2848,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-identify"
+version = "0.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c052d0026f4817b44869bfb6810f4e1112f43aec8553f2cb38881c524b563abf"
+dependencies = [
+ "asynchronous-codec",
+ "futures",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "lru",
+ "prost",
+ "prost-build",
+ "prost-codec",
+ "smallvec",
+ "thiserror",
+ "void",
+]
+
+[[package]]
 name = "libp2p-kad"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,6 +2924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad8a64f29da86005c86a4d2728b8a0719e9b192f4092b609fd8790acb9dec55"
 dependencies = [
  "libp2p-core",
+ "libp2p-identify",
  "libp2p-ping",
  "libp2p-swarm",
  "prometheus-client",
@@ -3155,6 +3178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "lru"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -3,9 +3,9 @@ mod args;
 use args::{CliArgs, Commands};
 use clap::Parser;
 
-use zinnia_runtime::colors;
 use zinnia_runtime::deno_core;
 use zinnia_runtime::fmt_errors::format_js_error;
+use zinnia_runtime::{colors, BootstrapOptions};
 use zinnia_runtime::{run_js_module, AnyError};
 
 use deno_core::error::JsError;
@@ -28,7 +28,11 @@ async fn main_impl() -> Result<(), AnyError> {
     match cli_args.command {
         Commands::Run { file } => {
             let main_module = deno_core::resolve_path(&file)?;
-            run_js_module(&main_module, &Default::default()).await?;
+            let config = BootstrapOptions {
+                agent_version: format!("zinnia/{}", env!("CARGO_PKG_VERSION")),
+                ..Default::default()
+            };
+            run_js_module(&main_module, &config).await?;
             Ok(())
         }
     }

--- a/ext/libp2p/Cargo.toml
+++ b/ext/libp2p/Cargo.toml
@@ -36,7 +36,7 @@ features = [
     # "metrics",
     "mplex",
     "noise",
-    # "ping",
+    "ping",
     # "plaintext",
     # "pnet",
     # "quic",
@@ -62,45 +62,5 @@ features = [
 [dev-dependencies]
 env_logger.workspace = true
 rand = "0.8.5"
-
-[dev-dependencies.libp2p]
-version = "0.50.0"
-features = [
-    # "async-std",
-    # "autonat",
-    # "dcutr",
-    # "deflate",
-    # "dns",
-    # "ecdsa",
-    # "floodsub",
-    # "gossipsub",
-    # "identify",
-    # "kad",
-    # "mdns",
-    # "metrics",
-    # "mplex",
-    # "noise",
-    "ping",
-    # "plaintext",
-    # "pnet",
-    # "quic",
-    # "macros",
-    # "relay",
-    # "rendezvous",
-    # "request-response",
-    # "rsa",
-    # "secp256k1",
-    # "serde",
-    # "tcp",
-    # "tls",
-    # "tokio",
-    # "uds",
-    # "wasm-bindgen",
-    # "wasm-ext",
-    # "wasm-ext-websocket",
-    # "webrtc",
-    # "websocket",
-    # "yamux",
-]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/ext/libp2p/Cargo.toml
+++ b/ext/libp2p/Cargo.toml
@@ -61,6 +61,7 @@ features = [
 
 [dev-dependencies]
 env_logger.workspace = true
+rand = "0.8.5"
 
 [dev-dependencies.libp2p]
 version = "0.50.0"

--- a/ext/libp2p/Cargo.toml
+++ b/ext/libp2p/Cargo.toml
@@ -30,7 +30,7 @@ features = [
     # "ecdsa",
     # "floodsub",
     # "gossipsub",
-    # "identify",
+    "identify",
     # "kad",
     # "mdns",
     # "metrics",

--- a/ext/libp2p/lib.rs
+++ b/ext/libp2p/lib.rs
@@ -6,7 +6,9 @@ use deno_core::error::AnyError;
 use deno_core::{include_js_files, op, Extension, OpState, ZeroCopyBuf};
 use libp2p::multiaddr::Protocol;
 use libp2p::{Multiaddr, PeerId};
-use peer::{PeerNode, PeerNodeConfig};
+use peer::PeerNode;
+
+pub use peer::PeerNodeConfig;
 
 mod peer;
 

--- a/ext/libp2p/lib.rs
+++ b/ext/libp2p/lib.rs
@@ -15,7 +15,7 @@ mod peer;
 #[derive(Clone, Debug, Default)]
 pub struct Options {
     /// Configuration options for the built-in (default) peer node
-    default_peer: PeerNodeConfig,
+    pub default_peer: PeerNodeConfig,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/ext/libp2p/peer.rs
+++ b/ext/libp2p/peer.rs
@@ -194,6 +194,28 @@ pub fn create_transport(
     Ok(tcp_transport)
 }
 
+#[derive(NetworkBehaviour)]
+struct NodeBehaviour {
+    pub ping: libp2p::ping::Behaviour,
+    pub zinnia: RequestResponse,
+}
+
+#[derive(Debug)]
+enum Command {
+    Dial {
+        peer_id: PeerId,
+        peer_addr: Multiaddr,
+        sender: oneshot::Sender<Result<(), Box<dyn Error + Send>>>,
+    },
+    Request {
+        peer_id: PeerId,
+        protocol: ProtocolInfo,
+        payload: RequestPayload,
+        sender: oneshot::Sender<Result<ResponsePayload, Box<dyn Error + Send>>>,
+    },
+    Shutdown,
+}
+
 pub struct EventLoop {
     swarm: Swarm<NodeBehaviour>,
     command_receiver: mpsc::Receiver<Command>,
@@ -407,28 +429,6 @@ impl EventLoop {
             }
         }
     }
-}
-
-#[derive(NetworkBehaviour)]
-struct NodeBehaviour {
-    pub ping: libp2p::ping::Behaviour,
-    pub zinnia: RequestResponse,
-}
-
-#[derive(Debug)]
-enum Command {
-    Dial {
-        peer_id: PeerId,
-        peer_addr: Multiaddr,
-        sender: oneshot::Sender<Result<(), Box<dyn Error + Send>>>,
-    },
-    Request {
-        peer_id: PeerId,
-        protocol: ProtocolInfo,
-        payload: RequestPayload,
-        sender: oneshot::Sender<Result<ResponsePayload, Box<dyn Error + Send>>>,
-    },
-    Shutdown,
 }
 
 #[cfg(test)]

--- a/ext/libp2p/peer/config.rs
+++ b/ext/libp2p/peer/config.rs
@@ -1,19 +1,30 @@
 use std::time::Duration;
 
+use libp2p::identify;
+use libp2p::identity::PublicKey;
 pub use libp2p::ping::Config as PingConfig;
 
 use super::behaviour::RequestResponseConfig;
 
 #[derive(Debug, Clone)]
 pub struct PeerNodeConfig {
+    /// Name and version of the local peer implementation, similar to the
+    /// `User-Agent` header in the HTTP protocol.
+    ///
+    /// This value will be reported via the `identify` protocol.
+    pub agent_version: String,
+
     pub request_timeout: Duration,
     pub connection_keep_alive: Duration,
+
+    /// Configuration for the built-in `ping` protocol
     pub ping: PingConfig,
 }
 
 impl Default for PeerNodeConfig {
     fn default() -> Self {
         Self {
+            agent_version: Self::default_agent_version(),
             connection_keep_alive: Duration::from_secs(10),
             request_timeout: Duration::from_secs(10),
             ping: Default::default(),
@@ -22,6 +33,10 @@ impl Default for PeerNodeConfig {
 }
 
 impl PeerNodeConfig {
+    pub fn default_agent_version() -> String {
+        format!("zinnia-libp2p/{}", env!("CARGO_PKG_VERSION"))
+    }
+
     pub fn request_response_config(&self) -> RequestResponseConfig {
         RequestResponseConfig {
             request_timeout: self.request_timeout,
@@ -31,5 +46,10 @@ impl PeerNodeConfig {
 
     pub fn ping_config(&self) -> PingConfig {
         self.ping.clone()
+    }
+
+    pub fn id_config(&self, local_public_key: PublicKey) -> identify::Config {
+        identify::Config::new("ipfs/1.0.0".into(), local_public_key.clone())
+            .with_agent_version(self.agent_version.clone())
     }
 }

--- a/ext/libp2p/peer/config.rs
+++ b/ext/libp2p/peer/config.rs
@@ -49,7 +49,7 @@ impl PeerNodeConfig {
     }
 
     pub fn id_config(&self, local_public_key: PublicKey) -> identify::Config {
-        identify::Config::new("ipfs/1.0.0".into(), local_public_key.clone())
+        identify::Config::new("ipfs/1.0.0".into(), local_public_key)
             .with_agent_version(self.agent_version.clone())
     }
 }

--- a/ext/libp2p/peer/config.rs
+++ b/ext/libp2p/peer/config.rs
@@ -1,0 +1,35 @@
+use std::time::Duration;
+
+pub use libp2p::ping::Config as PingConfig;
+
+use super::behaviour::RequestResponseConfig;
+
+#[derive(Debug, Clone)]
+pub struct PeerNodeConfig {
+    pub request_timeout: Duration,
+    pub connection_keep_alive: Duration,
+    pub ping: PingConfig,
+}
+
+impl Default for PeerNodeConfig {
+    fn default() -> Self {
+        Self {
+            connection_keep_alive: Duration::from_secs(10),
+            request_timeout: Duration::from_secs(10),
+            ping: Default::default(),
+        }
+    }
+}
+
+impl PeerNodeConfig {
+    pub fn request_response_config(&self) -> RequestResponseConfig {
+        RequestResponseConfig {
+            request_timeout: self.request_timeout,
+            connection_keep_alive: self.connection_keep_alive,
+        }
+    }
+
+    pub fn ping_config(&self) -> PingConfig {
+        self.ping.clone()
+    }
+}

--- a/runtime/tests/runtime_integration_tests.rs
+++ b/runtime/tests/runtime_integration_tests.rs
@@ -5,7 +5,7 @@
 //   deno run runtime/tests/js/timers_tests.js
 use std::path::PathBuf;
 
-use zinnia_runtime::{deno_core, run_js_module, AnyError};
+use zinnia_runtime::{deno_core, run_js_module, AnyError, BootstrapOptions};
 
 macro_rules! js_tests(
   ( $name:ident ) => {
@@ -29,7 +29,11 @@ async fn run_js_test_file(name: &str) -> Result<(), AnyError> {
     full_path.push(name);
 
     let main_module = deno_core::resolve_path(&full_path.to_string_lossy())?;
-    run_js_module(&main_module, &Default::default()).await?;
+    let config = BootstrapOptions {
+        agent_version: format!("zinnia_runtime_tests/{}", env!("CARGO_PKG_VERSION")),
+        ..Default::default()
+    };
+    run_js_module(&main_module, &config).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Enable handling of `Ping` and `Identify` requests by all Zinnia nodes.

This fixes compatibility with the rust-libp2p implementation of Ping protocol, which we need to allow us to test our request-response-like behavior against a Ping protocol implementation.

This is a follow-up for
- #83 
- #84

and a part of
- #73