### PR TITLE
ci: remove deprecated 3rd-party GH actions

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -9,6 +9,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo install cargo-audit
+      - run: cargo audit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,9 +145,7 @@ jobs:
           save-if: false
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: custom-clippy # cargo alias to allow reuse of config locally
+        run: cargo custom-clippy # cargo alias to allow reuse of config locally
 
   rustfmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- ci: remove deprecated `actions-rs/audit-check`
- ci: remove deprecated `actions-rs/cargo`

Close #68, see also
- #73

