### PR TITLE
feat: allow 0-RTT protocol negotiation

### DIFF
--- a/ext/libp2p/peer.rs
+++ b/ext/libp2p/peer.rs
@@ -184,7 +184,7 @@ pub fn create_transport(
     let tcp_transport = libp2p::dns::TokioDnsConfig::system(libp2p::tcp::tokio::Transport::new(
         libp2p::tcp::Config::new(),
     ))?
-    .upgrade(upgrade::Version::V1)
+    .upgrade(upgrade::Version::V1Lazy)
     .authenticate(noise::NoiseAuthenticated::xx(id_keys)?)
     .multiplex(upgrade::SelectUpgrade::new(
         yamux::YamuxConfig::default(),


### PR DESCRIPTION
Use "v1 lazy" variant of multistream-select.

> A "lazy" variant is identical on the wire but whereby the dialer
> delays flushing protocol negotiation data in order to combine it
> with initial application data, thus performing 0-RTT negotiation.

Based on the discussion in https://github.com/filecoin-station/zinnia/pull/48#discussion_r1117196369
