### PR TITLE
ci: upload release binaries to GH Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: zinnia-windows-x64.zip
-            rustflags: -C lto=off
-            #          ^^^^^^^^^^
+            rustflags: -C target-feature=+crt-static -C lto=off
+            #                                        ^^^^^^^^^^
             # LTO is temporarily disabled, see https://github.com/rust-lang/rust/issues/107781
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: zinnia-x86_64-pc-windows-msvc.zip
-            rustflags: -C target-feature=+crt-static -C lto=off
-            #                                        ^^^^^^^^^^
+            rustflags: -C lto=off
+            #          ^^^^^^^^^^
             # LTO is temporarily disabled, see https://github.com/rust-lang/rust/issues/107781
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,6 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
 
-      - name: Setup | Rust Cache
-        uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f # v2.2.1
-        with:
-          shared-key: release-${{ matrix.target }}
-
       - name: Build | Build
         run: cargo build --release --locked --target ${{ matrix.target }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,5 @@ jobs:
       - name: Release | Upload artifacts
         uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
           files: ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,8 @@ jobs:
           cd -
 
       - name: Release | Upload artifacts
-        uses: svenstaro/upload-release-action@7319e4733ec7a184d739a6f412c40ffc339b69c7 # 2.5.0
+        uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ matrix.name }}
-          prerelease: true
+          draft: true
+          files: ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,3 +81,4 @@ jobs:
         with:
           draft: true
           files: ${{ matrix.name }}
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,8 @@ jobs:
           cd -
 
       - name: Release | Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: svenstaro/upload-release-action@7319e4733ec7a184d739a6f412c40ffc339b69c7 # 2.5.0
         with:
-          name: ${{ matrix.name }}
-          path: ${{ matrix.name }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ matrix.name }}
+          prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,9 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: zinnia-x86_64-pc-windows-msvc.zip
-            rustflags: -C target-feature=+crt-static
+            rustflags: -C target-feature=+crt-static -C lto=off
+            #                                        ^^^^^^^^^^
+            # LTO is temporarily disabled, see https://github.com/rust-lang/rust/issues/107781
 
     runs-on: ${{ matrix.os }}
     continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,19 +23,19 @@ jobs:
           # List of platforms, this must be in sync with the list of platforms in ci.yaml
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            name: zinnia-x86_64-unknown-linux-gnu.tar.gz
+            name: zinnia-linux-x64.tar.gz
 
           - target: x86_64-apple-darwin
             os: macos-latest
-            name: zinnia-x86_64-apple-darwin.tar.gz
+            name: zinnia-macos-x64.tar.gz
 
           - target: aarch64-apple-darwin
             os: macos-latest
-            name: zinnia-aarch64-apple-darwin.tar.gz
+            name: zinnia-macos-arm64.tar.gz
 
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            name: zinnia-x86_64-pc-windows-msvc.zip
+            name: zinnia-windows-x64.zip
             rustflags: -C lto=off
             #          ^^^^^^^^^^
             # LTO is temporarily disabled, see https://github.com/rust-lang/rust/issues/107781

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ zinnia_libp2p = { version = "0.2.0", path = "./ext/libp2p" }
 
 [profile.release]
 codegen-units = 1
-incremental = true
 lto = true
 opt-level = 3
 


### PR DESCRIPTION
- Before this change, we were attaching the uploaded binaries to the workflow run. This PR changes the workflow to attach the binaries to a GH Release.
- Disable LTO on Windows in an attempt to fix the failing release build
- Rename release binaries
- Disable incremental release builds

See #23
