### PR TITLE
feat: upgrade Deno core and extensions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
+          # Support Windows: https://github.com/filecoin-station/zinnia/issues/99
           # - target: x86_64-pc-windows-msvc
           #   os: windows-latest
           - target: x86_64-unknown-linux-gnu

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,8 @@ jobs:
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
+          # - target: x86_64-pc-windows-msvc
+          #   os: windows-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,12 @@ jobs:
             os: macos-latest
             name: zinnia-macos-arm64.zip
 
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            name: zinnia-windows-x64.zip
-            rustflags: -C target-feature=+crt-static -C lto=off
-            #                                        ^^^^^^^^^^
-            # LTO is temporarily disabled, see https://github.com/rust-lang/rust/issues/107781
+          # - target: x86_64-pc-windows-msvc
+          #   os: windows-latest
+          #   name: zinnia-windows-x64.zip
+          #   rustflags: -C target-feature=+crt-static -C lto=off
+          #   #                                        ^^^^^^^^^^
+          #   # LTO is temporarily disabled, see https://github.com/rust-lang/rust/issues/107781
 
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
             os: macos-latest
             name: zinnia-macos-arm64.zip
 
+          # Support Windows: https://github.com/filecoin-station/zinnia/issues/99
           # - target: x86_64-pc-windows-msvc
           #   os: windows-latest
           #   name: zinnia-windows-x64.zip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +334,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ast_node"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf94863c5fdfee166d0907c44e5fee970123b2b7307046d35d1e671aa93afbba"
+dependencies = [
+ "darling 0.13.4",
+ "pmutil",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "swc_macros_common",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +477,15 @@ name = "base64ct"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+
+[[package]]
+name = "better_scoped_tls"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73e8ecdec39e98aa3b19e8cd0b8ed8f77ccb86a6b0b2dc7cd86d105438a2123"
+dependencies = [
+ "scoped-tls",
+]
 
 [[package]]
 name = "bincode"
@@ -1010,12 +1043,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.3",
+ "darling_macro 0.14.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "strsim",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1034,13 +1091,37 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.3",
  "quote 1.0.23",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -1076,10 +1157,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
 
 [[package]]
-name = "deno_broadcast_channel"
-version = "0.83.0"
+name = "deno_ast"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eaddf316a5c63eabe962d8304fbd5f9fa6d360cc6972e72ee541b34b5cd2f88"
+checksum = "76e007f9f03be5484596ea6bed86ffdc6357ba9660cb8da20845baf2ce079722"
+dependencies = [
+ "anyhow",
+ "base64 0.13.1",
+ "data-url",
+ "dprint-swc-ext",
+ "serde",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_codegen_macros",
+ "swc_ecma_loader",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_classes",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_transforms_proposal",
+ "swc_ecma_transforms_react",
+ "swc_ecma_transforms_typescript",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "text_lines",
+ "url",
+]
+
+[[package]]
+name = "deno_broadcast_channel"
+version = "0.85.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66646a76b98b6ecfd28208585ae9b32eed49a322566c31e77f23d1efe41ce334"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1089,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "deno_cache"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8d1a44cb8c8d18eda0b95b1078f274a29089eb6dd21766a9ecf4ad6cbac685"
+checksum = "93287fbe008c206ccdcb839713c6c3343083c82f97a3a8c6d0d1652e65d07acb"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1103,18 +1214,18 @@ dependencies = [
 
 [[package]]
 name = "deno_console"
-version = "0.89.0"
+version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cda6cf4635c2261951074023288f23756ac6852e7e63a6bd416a88f0e98c52e"
+checksum = "5290ad8855794d107dd7faa325f3e0e6f7f9a161205203aa0c1658f9c8852425"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.171.0"
+version = "0.173.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc41944f05dfeacfc2610e91f40ddcf246f3aeeac8ae4c26df46bfbf01a3902"
+checksum = "e3f5ea1db875ff1eb020c04b900f75c810a9b66deec4a5437205b868bff9a7df"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1137,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto"
-version = "0.103.0"
+version = "0.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e2a590be03f643d1147e12e8bc2fb04671b9bd68da9c8857d7d0b11a0255c"
+checksum = "065d18924326e14e217b366645c4a3c15680ce9f1b97d830e45bca0a7ce76581"
 dependencies = [
  "aes 0.8.2",
  "aes-gcm 0.10.1",
@@ -1174,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "deno_fetch"
-version = "0.113.0"
+version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c2ec54d6332b454cad9391e8b9c33edce79837ece8ffaca0f08ab957f78590"
+checksum = "15422dcb563e7cec4adf7ead77811147b3eb9b9ee0e3100979f98297a7b6368b"
 dependencies = [
  "bytes",
  "data-url",
@@ -1193,24 +1304,26 @@ dependencies = [
 
 [[package]]
 name = "deno_ffi"
-version = "0.76.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11cbb59638f05f3d4ffcb107a91491f70ddc86b93759be1f3858ffd4efd45f6"
+checksum = "837b7d24fe8b6aa20dfb46981857e07ceeb24fc31827dbad95aa093241362a1a"
 dependencies = [
  "deno_core",
  "dlopen",
  "dynasmrt",
  "libffi",
  "serde",
+ "serde-value",
+ "serde_json",
  "tokio",
  "winapi",
 ]
 
 [[package]]
 name = "deno_flash"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e6067e14bc4d904b53bd7a4f665eaa119ce31bc1bdb3913d41331de84f0a69"
+checksum = "b03448283116a9ecc9537e730af4ccbbf6a74837a3f3b84a1cb2d5baf64c4126"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -1229,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "deno_http"
-version = "0.84.0"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868bce9321850c1f2689846e8f031144efa5a7ae197d2839013c576c9b849167"
+checksum = "af7598c56a295086870eedd85329de1806d5a5b7cf8ce048dbbbb68e4e04116f"
 dependencies = [
  "async-compression",
  "base64 0.13.1",
@@ -1255,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "deno_napi"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42ac68f4f95a5b786d76aacabfb0e0eb1817841159132b6ac72d6a6dba95429"
+checksum = "97057fb0c11fe8bd016fb998082cdee3f831aa12a0d80c534a875c8ac4ec50db"
 dependencies = [
  "deno_core",
  "libloading",
@@ -1265,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "deno_net"
-version = "0.81.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed32765651e169918c9bb7f92d03b4b618401e8744d6a6ce6cc0d89ac4bda01"
+checksum = "f0f6df34bcf15bf4e5ff0345e5a349c209fb5eb19189a39c4b1df09fc6a91450"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -1281,22 +1394,34 @@ dependencies = [
 
 [[package]]
 name = "deno_node"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31411684ae279034f4fdd1fb9d0f2207eeaa7a717fdf490c26b00a22775f08d7"
+checksum = "a6b37e01ccc67c6c414064ba08d66071104b4340acc528a119ea5be73b086715"
 dependencies = [
  "deno_core",
+ "digest 0.10.6",
+ "idna 0.3.0",
+ "indexmap",
+ "md-5",
+ "md4",
  "once_cell",
  "path-clean",
+ "rand 0.8.5",
  "regex",
+ "ripemd",
+ "rsa",
  "serde",
+ "sha-1 0.10.0",
+ "sha2 0.10.6",
+ "sha3",
+ "typenum",
 ]
 
 [[package]]
 name = "deno_ops"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4740bc5738ad07dc1f523a232a4079a995fa2ad11efd71e09e8e32bf28f21ee1"
+checksum = "1d06332c139917f0fe6722e6c9bd3aac45bfdf3e306627e7eb681a42bad56497"
 dependencies = [
  "once_cell",
  "pmutil",
@@ -1309,11 +1434,12 @@ dependencies = [
 
 [[package]]
 name = "deno_runtime"
-version = "0.97.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29105932da08341683a01a5460ff683c7bcdf23efbaaf6057e75ecd710fb064b"
+checksum = "04cfc6a8b988a9c8c617e9a83969ce5c34219c77793f6c266936c95500c32d7c"
 dependencies = [
  "atty",
+ "deno_ast",
  "deno_broadcast_channel",
  "deno_cache",
  "deno_console",
@@ -1361,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "deno_tls"
-version = "0.76.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b82b9b18941a42be4108f79f14e8b5a29067e27619293d710324e0dd77d5d8"
+checksum = "46cac58432baf003b8f223c86118a54ffafe5d0a51c8196c0f42409b96e94c35"
 dependencies = [
  "deno_core",
  "once_cell",
@@ -1377,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "deno_url"
-version = "0.89.0"
+version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fe82b011d8b2af63c4587551536d951f47ffc3ba2a710e455b383d4f4b06ba"
+checksum = "bf7e791aa935afc79258e31083f8c0c940f3fe063226d11122149197c41b47c5"
 dependencies = [
  "deno_core",
  "serde",
@@ -1389,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.120.0"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7379502a7a333f573949558803e8bfe2e8fba3ef180cdbb4a882951803c87d20"
+checksum = "c61f6d9f990fefe637d6ee6eb9de416b3c113dfef36d73946e37dbe0bfbcefcd"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -1405,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "deno_webgpu"
-version = "0.90.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b430c70badca6edaf058d08dc622d931355726badc180134db49913270bcf2f"
+checksum = "93066e0f695515d3cf1eaea7edf2e1232d21445a102301ef36f1a9819cad312c"
 dependencies = [
  "deno_core",
  "serde",
@@ -1418,18 +1544,18 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.89.0"
+version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d046c6ac75f22be851219f44824c42927345f51e0ae5fb825e8bf8ea658d8ee8"
+checksum = "3bcf5027f4ab41174cb6ed30afb4a11c0c519db2287a00c6290b939f7ba83bfe"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_websocket"
-version = "0.94.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe8ce87cc7da7b4b0575d5686cafbdb306cb33bf04f33ff6e99325c88f44933"
+checksum = "fb839d2e6e574d87984687037e957c8699528130351043bdc6f392eb8005da8c"
 dependencies = [
  "deno_core",
  "deno_tls",
@@ -1443,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "deno_webstorage"
-version = "0.84.0"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b25958fe8143a02c86971890b7fa08a888e6a8a201e4918ea49220c092c361"
+checksum = "8cfa81bd857bece07e8c4fe771992f82dd3d050025b0d5fa3b1b0e12d2daca8c"
 dependencies = [
  "deno_core",
  "deno_web",
@@ -1507,7 +1633,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
 dependencies = [
- "darling",
+ "darling 0.14.3",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "syn 1.0.107",
@@ -1617,6 +1743,22 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dprint-swc-ext"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e2dc99247101e0132a17680c5afbba9a7334477b47738dd3431c13f5e2c9a84"
+dependencies = [
+ "bumpalo",
+ "num-bigint",
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "text_lines",
+]
 
 [[package]]
 name = "dtoa"
@@ -1737,6 +1879,18 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.51",
  "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "enum_kind"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b940da354ae81ef0926c5eaa428207b8f4f091d3956c891dfbd124162bed99"
+dependencies = [
+ "pmutil",
+ "proc-macro2 1.0.51",
+ "swc_macros_common",
  "syn 1.0.107",
 ]
 
@@ -1884,6 +2038,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "from_variant"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0981e470d2ab9f643df3921d54f1952ea100c39fdb6a3fdc820e20d2291df6c"
+dependencies = [
+ "pmutil",
+ "proc-macro2 1.0.51",
+ "swc_macros_common",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2602,6 +2768,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
+name = "is-macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7d079e129b77477a49c5c4f1cfe9ce6c2c909ef52520693e8e811a714c7b20"
+dependencies = [
+ "Inflector",
+ "pmutil",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,6 +2826,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +2872,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin",
+]
+
+[[package]]
+name = "lexical"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7aefb36fd43fef7003334742cbf77b243fcd36418a1d1bdd480d613a67968f6"
+dependencies = [
+ "lexical-core",
+]
+
+[[package]]
+name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3238,6 +3499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "md4"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da5ac363534dce5fabf69949225e174fbf111a498bf0ff794c8ea1fba9f3dda"
+dependencies = [
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,6 +3754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
 name = "nix"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,6 +3832,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -3670,6 +3947,15 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -3789,6 +4075,12 @@ name = "path-clean"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pem"
@@ -4010,6 +4302,12 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
@@ -4489,6 +4787,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4703,6 +5010,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4817,6 +5130,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4873,9 +5196,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.82.0"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060fd38f18c420e82ab21592ec1f088b39bccb6897b1dda394d63628e22158d"
+checksum = "94c6b0ea68c2368070520883b5caac9b5bff17597cfac77aebc07280e8585f7f"
 dependencies = [
  "bytes",
  "derive_more",
@@ -4896,6 +5219,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -4931,6 +5265,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+dependencies = [
+ "digest 0.10.6",
+ "keccak",
 ]
 
 [[package]]
@@ -5051,10 +5395,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+]
+
+[[package]]
+name = "string_enum"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994453cd270ad0265796eb24abf5540091ed03e681c5f3c12bc33e4db33253e1"
+dependencies = [
+ "pmutil",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "swc_macros_common",
+ "syn 1.0.107",
+]
 
 [[package]]
 name = "strsim"
@@ -5095,6 +5484,345 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "swc_atoms"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731cf66bd8e11030f056f91f9d8af77f83ec4377ff04d1670778a57d1607402a"
+dependencies = [
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "string_cache",
+ "string_cache_codegen",
+ "triomphe",
+]
+
+[[package]]
+name = "swc_common"
+version = "0.29.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97e491d31418cd33fea58e9f893316fc04b30e2b5d0e750c066e2ba4907ae54"
+dependencies = [
+ "ahash",
+ "ast_node",
+ "better_scoped_tls",
+ "cfg-if",
+ "either",
+ "from_variant",
+ "new_debug_unreachable",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "siphasher",
+ "sourcemap",
+ "string_cache",
+ "swc_atoms",
+ "swc_eq_ignore_macros",
+ "swc_visit",
+ "tracing",
+ "unicode-width",
+ "url",
+]
+
+[[package]]
+name = "swc_config"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4de36224eb9498fccd4e68971f0b83326ccf8592c2d424f257f3a1c76b2b211"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "swc_config_macro",
+]
+
+[[package]]
+name = "swc_config_macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb64bc03d90fd5c90d6ab917bb2b1d7fbd31957df39e31ea24a3f554b4372251"
+dependencies = [
+ "pmutil",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "swc_macros_common",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "swc_ecma_ast"
+version = "0.96.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a887102d5595b557261aa4bde35f3d71906fba674d4b79cd5c59b4155b12ee2d"
+dependencies = [
+ "bitflags",
+ "is-macro",
+ "num-bigint",
+ "scoped-tls",
+ "serde",
+ "string_enum",
+ "swc_atoms",
+ "swc_common",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_codegen"
+version = "0.129.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f8f20522626a737753381bdf64ee53d568730f9f7e720d35960de97e5ff965"
+dependencies = [
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "sourcemap",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen_macros",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_codegen_macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0159c99f81f52e48fe692ef7af1b0990b45d3006b14c6629be0b1ffee1b23aea"
+dependencies = [
+ "pmutil",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "swc_macros_common",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "swc_ecma_loader"
+version = "0.41.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c996baa947150d496c79fbd153d3df834e38d05c779abc4af987aded90e168a2"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "pathdiff",
+ "serde",
+ "swc_common",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "0.124.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e75888eabf1ad8a8968e3befc7cd20c10e4721254d3344285bd5c3a42f58dc1"
+dependencies = [
+ "either",
+ "enum_kind",
+ "lexical",
+ "num-bigint",
+ "serde",
+ "smallvec",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "tracing",
+ "typed-arena",
+]
+
+[[package]]
+name = "swc_ecma_transforms_base"
+version = "0.116.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f5a212abba41897332f9ab3af8fe5d1a59f83d69e25eea119c27d9b53876688"
+dependencies = [
+ "better_scoped_tls",
+ "bitflags",
+ "once_cell",
+ "phf",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_classes"
+version = "0.105.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fd5a8eff1a7f16ec1b3ae50186debf3d3983effed6ed05d4e6db0ed7aadcac"
+dependencies = [
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+]
+
+[[package]]
+name = "swc_ecma_transforms_macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf907935ec5492256b523ae7935a824d9fdc0368dcadc41375bad0dca91cd8b"
+dependencies = [
+ "pmutil",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "swc_macros_common",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "swc_ecma_transforms_proposal"
+version = "0.149.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6fe11a20c7ced3c6b6149da330b8b4d8912fe02af6923aaac4d4479aa3dd3b6"
+dependencies = [
+ "either",
+ "serde",
+ "smallvec",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_classes",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+]
+
+[[package]]
+name = "swc_ecma_transforms_react"
+version = "0.160.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94e3884668e2e12684e4adf812dbd22d34b17da2d7637b1c9cffe393acad6c2"
+dependencies = [
+ "ahash",
+ "base64 0.13.1",
+ "dashmap",
+ "indexmap",
+ "once_cell",
+ "regex",
+ "serde",
+ "sha-1 0.10.0",
+ "string_enum",
+ "swc_atoms",
+ "swc_common",
+ "swc_config",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+]
+
+[[package]]
+name = "swc_ecma_transforms_typescript"
+version = "0.164.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a885199b43798b46d8b26b4a986f899436f9f2cb37477eb12a183388a5c213f"
+dependencies = [
+ "serde",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_react",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "0.107.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d773cf626c8d3be468a883879cda3727a2f1ea6169ccd0b5b8eb2d7afb5f367b"
+dependencies = [
+ "indexmap",
+ "num_cpus",
+ "once_cell",
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
+ "tracing",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "0.82.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2ee0f4b61d6c426189d0d9da1333705ff3bc4513fb63633ca254595a700f75"
+dependencies = [
+ "num-bigint",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_eq_ignore_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c20468634668c2bbab581947bb8c75c97158d5a6959f4ba33df20983b20b4f6"
+dependencies = [
+ "pmutil",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "swc_macros_common"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4be988307882648d9bc7c71a6a73322b7520ef0211e920489a98f8391d8caa2"
+dependencies = [
+ "pmutil",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "swc_visit"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470a1963cf182fdcbbac46e3a7fd2caf7329da0e568d3668202da9501c880e16"
+dependencies = [
+ "either",
+ "swc_visit_macros",
+]
+
+[[package]]
+name = "swc_visit_macros"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6098b717cfd4c85f5cddec734af191dbce461c39975ed567c32ac6d0c6d61a6d"
+dependencies = [
+ "Inflector",
+ "pmutil",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "swc_macros_common",
+ "syn 1.0.107",
+]
 
 [[package]]
 name = "syn"
@@ -5181,6 +5909,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
+name = "text_lines"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd5828de7deaa782e1dd713006ae96b3bee32d3279b79eb67ecf8072c059bcf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5263,9 +6000,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -5422,6 +6159,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ee9bd9239c339d714d657fac840c6d2a4f9c45f4f9ec7b0975113458be78db"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "trust-dns-proto"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5489,7 +6236,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustls 0.20.8",
- "sha-1",
+ "sha-1 0.9.8",
  "thiserror",
  "url",
  "utf-8",
@@ -5514,6 +6261,12 @@ dependencies = [
  "tokio",
  "webrtc-util",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
@@ -5700,9 +6453,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.60.1"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fd5b3ed559897ff02c0f62bc0a5f300bfe79bb4c77a50031b8df771701c628"
+checksum = "547e58962ac268fe0b1fbfb653ed341a08e3953994f7f7c978e46ec30afdf8f0"
 dependencies = [
  "bitflags",
  "fslock",
@@ -6009,7 +6762,7 @@ dependencies = [
  "rustls 0.19.1",
  "sec1",
  "serde",
- "sha-1",
+ "sha-1 0.9.8",
  "sha2 0.9.9",
  "signature",
  "subtle",
@@ -6108,7 +6861,7 @@ dependencies = [
  "log",
  "rtcp",
  "rtp",
- "sha-1",
+ "sha-1 0.9.8",
  "subtle",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/filecoin-station/zinnia"
 
 [workspace.dependencies]
 assert_fs = "1.0.10"
-deno_core = "0.171.0"
+deno_core = "0.173.0"
 log = "0.4.17"
 pretty_assertions = "1.3.0"
 env_logger = "0.10.0"

--- a/ext/libp2p/js/01_peer.js
+++ b/ext/libp2p/js/01_peer.js
@@ -1,48 +1,45 @@
-"use strict";
+const core = globalThis.Deno.core;
+const { ops, opAsync } = core;
 
-((window) => {
-  const core = window.Deno.core;
-  const ops = core.ops;
-
-  window.__bootstrap.libp2p ??= {};
-
-  async function requestProtocol(remoteAddress, protocolName, requestPayload) {
-    if (typeof remoteAddress !== "string")
-      throw new TypeError(`remoteAddress must be string (found: ${typeof remoteAddress})`);
-    if (typeof protocolName !== "string")
-      throw new TypeError(`protocolName must be string (found: ${typeof protocolName})`);
-    if (requestPayload?.constructor !== Uint8Array) {
-      const actualType = requestPayload?.constructor?.name ?? typeof requestPayload;
-      throw new TypeError(`requestPayload must be Uint8Array (found: ${actualType})`);
-    }
-
-    const responsePayload = await ops.op_p2p_request_protocol(
-      remoteAddress,
-      protocolName,
-      requestPayload,
-    );
-
-    return {
-      async *[Symbol.asyncIterator]() {
-        yield new Uint8Array(responsePayload);
-      },
-    };
+async function requestProtocol(remoteAddress, protocolName, requestPayload) {
+  if (typeof remoteAddress !== "string")
+    throw new TypeError(`remoteAddress must be string (found: ${typeof remoteAddress})`);
+  if (typeof protocolName !== "string")
+    throw new TypeError(`protocolName must be string (found: ${typeof protocolName})`);
+  if (requestPayload?.constructor !== Uint8Array) {
+    const actualType = requestPayload?.constructor?.name ?? typeof requestPayload;
+    throw new TypeError(`requestPayload must be Uint8Array (found: ${actualType})`);
   }
 
-  window.__bootstrap.libp2p.defaultPeerProps = {
-    peerId: {
-      get() {
-        return ops.op_p2p_get_peer_id();
-      },
-      enumerable: true,
-      configurable: true,
-    },
+  const responsePayload = await opAsync(
+    "op_p2p_request_protocol",
+    remoteAddress,
+    protocolName,
+    requestPayload,
+  );
 
-    requestProtocol: {
-      value: requestProtocol,
-      writable: false,
-      enumerable: true,
-      configurable: true,
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield new Uint8Array(responsePayload);
     },
   };
-})(globalThis);
+}
+
+const defaultPeerProps = {
+  peerId: {
+    get() {
+      return ops.op_p2p_get_peer_id();
+    },
+    enumerable: true,
+    configurable: true,
+  },
+
+  requestProtocol: {
+    value: requestProtocol,
+    writable: false,
+    enumerable: true,
+    configurable: true,
+  },
+};
+
+export { defaultPeerProps };

--- a/ext/libp2p/lib.rs
+++ b/ext/libp2p/lib.rs
@@ -23,9 +23,9 @@ struct DefaultNodeResourceId(deno_core::ResourceId);
 
 pub fn init(options: Options) -> Extension {
     Extension::builder(env!("CARGO_PKG_NAME"))
-        .js(include_js_files!(
-          prefix "internal:ext/libp2p",
-          "js/01_peer.js",
+        .esm(include_js_files!(
+            dir "js",
+             "01_peer.js",
         ))
         .ops(vec![
             op_p2p_get_peer_id::decl(),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,7 +12,7 @@ name = "zinnia_runtime"
 path = "lib.rs"
 
 [dependencies]
-deno_runtime = "0.97.0"
+deno_runtime = "0.99.0"
 log.workspace = true
 tokio = { workspace = true, features = ["fs"] }
 zinnia_libp2p.workspace = true

--- a/runtime/js/06_util.js
+++ b/runtime/js/06_util.js
@@ -1,83 +1,83 @@
 // ZINNIA VERSION: Copyright 2023 Protocol Labs. All rights reserved. MIT OR Apache-2.0 license.
 // ORIGINAL WORK: Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-// https://github.com/denoland/deno/blob/f3fb8ee18826e66d3896ea864d2bedaed6c79308/runtime/js/06_util.js
-"use strict";
+// https://github.com/denoland/deno/blob/86785f21194460d713276dca2/runtime/js/06_util.js
 
-((window) => {
-  const { Promise, SafeArrayIterator } = window.__bootstrap.primordials;
-  let logDebug = false;
-  let logSource = "JS";
+const primordials = globalThis.__bootstrap.primordials;
+const { Promise, SafeArrayIterator } = primordials;
 
-  function setLogDebug(debug, source) {
-    logDebug = debug;
-    if (source) {
-      logSource = source;
-    }
+let logDebug = false;
+let logSource = "JS";
+
+function setLogDebug(debug, source) {
+  logDebug = debug;
+  if (source) {
+    logSource = source;
   }
+}
 
-  function log(...args) {
-    if (logDebug) {
-      // if we destructure `console` off `globalThis` too early, we don't bind to
-      // the right console, therefore we don't log anything out.
-      globalThis.console.log(`DEBUG ${logSource} -`, ...new SafeArrayIterator(args));
-    }
+function log(...args) {
+  if (logDebug) {
+    // if we destructure `console` off `globalThis` too early, we don't bind to
+    // the right console, therefore we don't log anything out.
+    globalThis.console.log(`DEBUG ${logSource} -`, ...new SafeArrayIterator(args));
   }
+}
 
-  function createResolvable() {
-    let resolve;
-    let reject;
-    const promise = new Promise((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
-    promise.resolve = resolve;
-    promise.reject = reject;
-    return promise;
-  }
+function createResolvable() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  promise.resolve = resolve;
+  promise.reject = reject;
+  return promise;
+}
 
-  function writable(value) {
-    return {
-      value,
-      writable: true,
-      enumerable: true,
-      configurable: true,
-    };
-  }
-
-  function nonEnumerable(value) {
-    return {
-      value,
-      writable: true,
-      enumerable: false,
-      configurable: true,
-    };
-  }
-
-  function readOnly(value) {
-    return {
-      value,
-      enumerable: true,
-      writable: false,
-      configurable: true,
-    };
-  }
-
-  function getterOnly(getter) {
-    return {
-      get: getter,
-      set() {},
-      enumerable: true,
-      configurable: true,
-    };
-  }
-
-  window.__bootstrap.util = {
-    log,
-    setLogDebug,
-    createResolvable,
-    writable,
-    nonEnumerable,
-    readOnly,
-    getterOnly,
+function writable(value) {
+  return {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
   };
-})(this);
+}
+
+function nonEnumerable(value) {
+  return {
+    value,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  };
+}
+
+function readOnly(value) {
+  return {
+    value,
+    enumerable: true,
+    writable: false,
+    configurable: true,
+  };
+}
+
+function getterOnly(getter) {
+  return {
+    get: getter,
+    set() {},
+    enumerable: true,
+    configurable: true,
+  };
+}
+
+// prettier-ignore
+export {
+  createResolvable,
+  getterOnly,
+  log,
+  nonEnumerable,
+  readOnly,
+  setLogDebug,
+  writable,
+};

--- a/runtime/js/98_global_scope.js
+++ b/runtime/js/98_global_scope.js
@@ -1,142 +1,138 @@
 // ZINNIA VERSION: Copyright 2023 Protocol Labs. All rights reserved. MIT OR Apache-2.0 license.
 // ORIGINAL WORK: Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-// https://github.com/denoland/deno/blob/34bfa2cb2c1f0f74a94ced8fc164e81cc91cb9f4/runtime/js/98_global_scope.js
+// https://github.com/denoland/deno/blob/86785f21194460d713276dca2/runtime/js/98_global_scope.js
 
-"use strict";
+const core = globalThis.Deno.core;
+const primordials = globalThis.__bootstrap.primordials;
+const { ObjectDefineProperties, ObjectCreate } = primordials;
 
-((window) => {
-  const core = Deno.core;
+import * as util from "internal:zinnia_runtime/js/06_util.js";
+import * as event from "internal:deno_web/02_event.js";
+import * as timers from "internal:deno_web/02_timers.js";
+import * as base64 from "internal:deno_web/05_base64.js";
+import * as encoding from "internal:deno_web/08_text_encoding.js";
+import * as console from "internal:deno_console/02_console.js";
+import * as compression from "internal:deno_web/14_compression.js";
+import * as performance from "internal:deno_web/15_performance.js";
+import * as crypto from "internal:deno_crypto/00_crypto.js";
+import * as url from "internal:deno_url/00_url.js";
+import * as urlPattern from "internal:deno_url/01_urlpattern.js";
+import * as headers from "internal:deno_fetch/20_headers.js";
+import * as streams from "internal:deno_web/06_streams.js";
+import * as formData from "internal:deno_fetch/21_formdata.js";
+import * as request from "internal:deno_fetch/23_request.js";
+import * as response from "internal:deno_fetch/23_response.js";
+import * as fetch from "internal:deno_fetch/26_fetch.js";
+import * as messagePort from "internal:deno_web/13_message_port.js";
+import * as webidl from "internal:deno_webidl/00_webidl.js";
+import DOMException from "internal:deno_web/01_dom_exception.js";
+import * as abortSignal from "internal:deno_web/03_abort_signal.js";
+import * as globalInterfaces from "internal:deno_web/04_global_interfaces.js";
+import * as libp2p from "internal:zinnia_libp2p/js/01_peer.js";
 
-  const { ObjectCreate, ObjectDefineProperties } = window.__bootstrap.primordials;
+// https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope
+const windowOrWorkerGlobalScope = {
+  AbortController: util.nonEnumerable(abortSignal.AbortController),
+  AbortSignal: util.nonEnumerable(abortSignal.AbortSignal),
+  // Intentionally disabled until we need this.
+  // Blob: util.nonEnumerable(file.Blob),
+  ByteLengthQueuingStrategy: util.nonEnumerable(streams.ByteLengthQueuingStrategy),
+  CloseEvent: util.nonEnumerable(event.CloseEvent),
+  CompressionStream: util.nonEnumerable(compression.CompressionStream),
+  CountQueuingStrategy: util.nonEnumerable(streams.CountQueuingStrategy),
+  CryptoKey: util.nonEnumerable(crypto.CryptoKey),
+  CustomEvent: util.nonEnumerable(event.CustomEvent),
+  DecompressionStream: util.nonEnumerable(compression.DecompressionStream),
+  DOMException: util.nonEnumerable(DOMException),
+  ErrorEvent: util.nonEnumerable(event.ErrorEvent),
+  Event: util.nonEnumerable(event.Event),
+  EventTarget: util.nonEnumerable(event.EventTarget),
+  // Intentionally disabled until we need this.
+  // File: util.nonEnumerable(file.File),
+  // FileReader: util.nonEnumerable(fileReader.FileReader),
+  FormData: util.nonEnumerable(formData.FormData),
+  Headers: util.nonEnumerable(headers.Headers),
+  MessageEvent: util.nonEnumerable(event.MessageEvent),
+  Performance: util.nonEnumerable(performance.Performance),
+  PerformanceEntry: util.nonEnumerable(performance.PerformanceEntry),
+  PerformanceMark: util.nonEnumerable(performance.PerformanceMark),
+  PerformanceMeasure: util.nonEnumerable(performance.PerformanceMeasure),
+  PromiseRejectionEvent: util.nonEnumerable(event.PromiseRejectionEvent),
+  ProgressEvent: util.nonEnumerable(event.ProgressEvent),
+  ReadableStream: util.nonEnumerable(streams.ReadableStream),
+  ReadableStreamDefaultReader: util.nonEnumerable(streams.ReadableStreamDefaultReader),
+  Request: util.nonEnumerable(request.Request),
+  Response: util.nonEnumerable(response.Response),
+  TextDecoder: util.nonEnumerable(encoding.TextDecoder),
+  TextEncoder: util.nonEnumerable(encoding.TextEncoder),
+  TextDecoderStream: util.nonEnumerable(encoding.TextDecoderStream),
+  TextEncoderStream: util.nonEnumerable(encoding.TextEncoderStream),
+  TransformStream: util.nonEnumerable(streams.TransformStream),
+  URL: util.nonEnumerable(url.URL),
+  URLPattern: util.nonEnumerable(urlPattern.URLPattern),
+  URLSearchParams: util.nonEnumerable(url.URLSearchParams),
+  // TODO(?): WebSocket Standard
+  // WebSocket: util.nonEnumerable(webSocket.WebSocket),
+  MessageChannel: util.nonEnumerable(messagePort.MessageChannel),
+  MessagePort: util.nonEnumerable(messagePort.MessagePort),
+  // TODO(?): Service & Web Workers
+  // Worker: util.nonEnumerable(worker.Worker),
+  WritableStream: util.nonEnumerable(streams.WritableStream),
+  WritableStreamDefaultWriter: util.nonEnumerable(streams.WritableStreamDefaultWriter),
+  WritableStreamDefaultController: util.nonEnumerable(streams.WritableStreamDefaultController),
+  ReadableByteStreamController: util.nonEnumerable(streams.ReadableByteStreamController),
+  ReadableStreamBYOBReader: util.nonEnumerable(streams.ReadableStreamBYOBReader),
+  ReadableStreamBYOBRequest: util.nonEnumerable(streams.ReadableStreamBYOBRequest),
+  ReadableStreamDefaultController: util.nonEnumerable(streams.ReadableStreamDefaultController),
+  TransformStreamDefaultController: util.nonEnumerable(streams.TransformStreamDefaultController),
+  atob: util.writable(base64.atob),
+  btoa: util.writable(base64.btoa),
+  clearInterval: util.writable(timers.clearInterval),
+  clearTimeout: util.writable(timers.clearTimeout),
+  // TODO(?): Service & Web Workers
+  // caches: {
+  //   enumerable: true,
+  //   configurable: true,
+  //   get: caches.cacheStorage,
+  // },
+  // CacheStorage: util.nonEnumerable(caches.CacheStorage),
+  // Cache: util.nonEnumerable(caches.Cache),
+  console: util.nonEnumerable(new console.Console((msg, level) => core.print(msg, level > 1))),
+  crypto: util.readOnly(crypto.crypto),
+  Crypto: util.nonEnumerable(crypto.Crypto),
+  SubtleCrypto: util.nonEnumerable(crypto.SubtleCrypto),
+  fetch: util.writable(fetch.fetch),
+  performance: util.writable(performance.performance),
+  reportError: util.writable(event.reportError),
+  setInterval: util.writable(timers.setInterval),
+  setTimeout: util.writable(timers.setTimeout),
+  structuredClone: util.writable(messagePort.structuredClone),
+  // Branding as a WebIDL object
+  [webidl.brand]: util.nonEnumerable(webidl.brand),
+};
 
-  const util = window.__bootstrap.util;
-  const event = window.__bootstrap.event;
-  const eventTarget = window.__bootstrap.eventTarget;
-  const timers = window.__bootstrap.timers;
-  const base64 = window.__bootstrap.base64;
-  const encoding = window.__bootstrap.encoding;
-  const Console = window.__bootstrap.console.Console;
-  const compression = window.__bootstrap.compression;
-  const performance = window.__bootstrap.performance;
-  const crypto = window.__bootstrap.crypto;
-  const url = window.__bootstrap.url;
-  const urlPattern = window.__bootstrap.urlPattern;
-  const headers = window.__bootstrap.headers;
-  const streams = window.__bootstrap.streams;
-  const fileReader = window.__bootstrap.fileReader;
-  const file = window.__bootstrap.file;
-  const formData = window.__bootstrap.formData;
-  const fetch = window.__bootstrap.fetch;
-  const messagePort = window.__bootstrap.messagePort;
-  const webidl = window.__bootstrap.webidl;
-  const domException = window.__bootstrap.domException;
-  const abortSignal = window.__bootstrap.abortSignal;
-  const globalInterfaces = window.__bootstrap.globalInterfaces;
-  const libp2p = window.__bootstrap.libp2p;
+const zinniaNs = ObjectCreate(null);
+ObjectDefineProperties(zinniaNs, libp2p.defaultPeerProps);
 
-  // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope
-  const windowOrWorkerGlobalScope = {
-    AbortController: util.nonEnumerable(abortSignal.AbortController),
-    AbortSignal: util.nonEnumerable(abortSignal.AbortSignal),
-    // Intentionally disabled until we need this.
-    // Blob: util.nonEnumerable(file.Blob),
-    ByteLengthQueuingStrategy: util.nonEnumerable(streams.ByteLengthQueuingStrategy),
-    CloseEvent: util.nonEnumerable(event.CloseEvent),
-    CompressionStream: util.nonEnumerable(compression.CompressionStream),
-    CountQueuingStrategy: util.nonEnumerable(streams.CountQueuingStrategy),
-    CryptoKey: util.nonEnumerable(crypto.CryptoKey),
-    CustomEvent: util.nonEnumerable(event.CustomEvent),
-    DecompressionStream: util.nonEnumerable(compression.DecompressionStream),
-    DOMException: util.nonEnumerable(domException.DOMException),
-    ErrorEvent: util.nonEnumerable(event.ErrorEvent),
-    Event: util.nonEnumerable(event.Event),
-    EventTarget: util.nonEnumerable(eventTarget.EventTarget),
-    // Intentionally disabled until we need this.
-    // File: util.nonEnumerable(file.File),
-    // FileReader: util.nonEnumerable(fileReader.FileReader),
-    FormData: util.nonEnumerable(formData.FormData),
-    Headers: util.nonEnumerable(headers.Headers),
-    MessageEvent: util.nonEnumerable(event.MessageEvent),
-    Performance: util.nonEnumerable(performance.Performance),
-    PerformanceEntry: util.nonEnumerable(performance.PerformanceEntry),
-    PerformanceMark: util.nonEnumerable(performance.PerformanceMark),
-    PerformanceMeasure: util.nonEnumerable(performance.PerformanceMeasure),
-    PromiseRejectionEvent: util.nonEnumerable(event.PromiseRejectionEvent),
-    ProgressEvent: util.nonEnumerable(event.ProgressEvent),
-    ReadableStream: util.nonEnumerable(streams.ReadableStream),
-    ReadableStreamDefaultReader: util.nonEnumerable(streams.ReadableStreamDefaultReader),
-    Request: util.nonEnumerable(fetch.Request),
-    Response: util.nonEnumerable(fetch.Response),
-    TextDecoder: util.nonEnumerable(encoding.TextDecoder),
-    TextEncoder: util.nonEnumerable(encoding.TextEncoder),
-    TextDecoderStream: util.nonEnumerable(encoding.TextDecoderStream),
-    TextEncoderStream: util.nonEnumerable(encoding.TextEncoderStream),
-    TransformStream: util.nonEnumerable(streams.TransformStream),
-    URL: util.nonEnumerable(url.URL),
-    URLPattern: util.nonEnumerable(urlPattern.URLPattern),
-    URLSearchParams: util.nonEnumerable(url.URLSearchParams),
-    // TODO(?): WebSocket Standard
-    // WebSocket: util.nonEnumerable(webSocket.WebSocket),
-    MessageChannel: util.nonEnumerable(messagePort.MessageChannel),
-    MessagePort: util.nonEnumerable(messagePort.MessagePort),
-    // TODO(?): Service & Web Workers
-    // Worker: util.nonEnumerable(worker.Worker),
-    WritableStream: util.nonEnumerable(streams.WritableStream),
-    WritableStreamDefaultWriter: util.nonEnumerable(streams.WritableStreamDefaultWriter),
-    WritableStreamDefaultController: util.nonEnumerable(streams.WritableStreamDefaultController),
-    ReadableByteStreamController: util.nonEnumerable(streams.ReadableByteStreamController),
-    ReadableStreamBYOBReader: util.nonEnumerable(streams.ReadableStreamBYOBReader),
-    ReadableStreamBYOBRequest: util.nonEnumerable(streams.ReadableStreamBYOBRequest),
-    ReadableStreamDefaultController: util.nonEnumerable(streams.ReadableStreamDefaultController),
-    TransformStreamDefaultController: util.nonEnumerable(streams.TransformStreamDefaultController),
-    atob: util.writable(base64.atob),
-    btoa: util.writable(base64.btoa),
-    clearInterval: util.writable(timers.clearInterval),
-    clearTimeout: util.writable(timers.clearTimeout),
-    // TODO(?): Service & Web Workers
-    // caches: {
-    //   enumerable: true,
-    //   configurable: true,
-    //   get: caches.cacheStorage,
-    // },
-    // CacheStorage: util.nonEnumerable(caches.CacheStorage),
-    // Cache: util.nonEnumerable(caches.Cache),
-    console: util.nonEnumerable(new Console((msg, level) => core.print(msg, level > 1))),
-    crypto: util.readOnly(crypto.crypto),
-    Crypto: util.nonEnumerable(crypto.Crypto),
-    SubtleCrypto: util.nonEnumerable(crypto.SubtleCrypto),
-    fetch: util.writable(fetch.fetch),
-    performance: util.writable(performance.performance),
-    reportError: util.writable(event.reportError),
-    setInterval: util.writable(timers.setInterval),
-    setTimeout: util.writable(timers.setTimeout),
-    structuredClone: util.writable(messagePort.structuredClone),
-    // Branding as a WebIDL object
-    [webidl.brand]: util.nonEnumerable(webidl.brand),
-  };
+const mainRuntimeGlobalProperties = {
+  // Location: location.locationConstructorDescriptor,
+  // location: location.locationDescriptor,
+  Window: globalInterfaces.windowConstructorDescriptor,
+  window: util.getterOnly(() => globalThis),
+  self: util.getterOnly(() => globalThis),
+  // Navigator: util.nonEnumerable(Navigator),
+  // navigator: util.getterOnly(() => navigator),
+  // alert: util.writable(prompt.alert),
+  // confirm: util.writable(prompt.confirm),
+  // prompt: util.writable(prompt.prompt),
+  // localStorage: util.getterOnly(webStorage.localStorage),
+  // sessionStorage: util.getterOnly(webStorage.sessionStorage),
+  // Storage: util.nonEnumerable(webStorage.Storage),
+  Zinnia: util.readOnly(zinniaNs),
+};
 
-  const zinniaNs = ObjectCreate(null);
-  ObjectDefineProperties(zinniaNs, libp2p.defaultPeerProps);
-
-  const mainRuntimeGlobalProperties = {
-    // Location: location.locationConstructorDescriptor,
-    // location: location.locationDescriptor,
-    Window: globalInterfaces.windowConstructorDescriptor,
-    window: util.getterOnly(() => globalThis),
-    self: util.getterOnly(() => globalThis),
-    // Navigator: util.nonEnumerable(Navigator),
-    // navigator: util.getterOnly(() => navigator),
-    // alert: util.writable(prompt.alert),
-    // confirm: util.writable(prompt.confirm),
-    // prompt: util.writable(prompt.prompt),
-    // localStorage: util.getterOnly(webStorage.localStorage),
-    // sessionStorage: util.getterOnly(webStorage.sessionStorage),
-    // Storage: util.nonEnumerable(webStorage.Storage),
-    Zinnia: util.readOnly(zinniaNs),
-  };
-
-  window.__bootstrap.globalScope = {
-    windowOrWorkerGlobalScope,
-    mainRuntimeGlobalProperties,
-  };
-})(this);
+// prettier-ignore
+export {
+  windowOrWorkerGlobalScope,
+  mainRuntimeGlobalProperties,
+};

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -1,8 +1,6 @@
 // ZINNIA VERSION: Copyright 2023 Protocol Labs. All rights reserved. MIT OR Apache-2.0 license.
 // ORIGINAL WORK: Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-// https://github.com/denoland/deno/blob/34bfa2cb2c1f0f74a94ced8fc164e81cc91cb9f4/runtime/js/99_main.js
-
-"use strict";
+// https://github.com/denoland/deno/blob/86785f21194460d713276dca2/runtime/js/99_main.js
 
 // Removes the `__proto__` for security reasons.
 // https://tc39.es/ecma262/#sec-get-object.prototype.__proto__
@@ -11,97 +9,100 @@ delete Object.prototype.__proto__;
 // Remove Intl.v8BreakIterator because it is a non-standard API.
 delete Intl.v8BreakIterator;
 
-((window) => {
-  const core = Deno.core;
-  const ops = core.ops;
-  const {
-    Error,
-    ErrorPrototype,
-    ObjectDefineProperties,
-    ObjectPrototypeIsPrototypeOf,
-    ObjectSetPrototypeOf,
-  } = window.__bootstrap.primordials;
-  const eventTarget = window.__bootstrap.eventTarget;
-  const timers = window.__bootstrap.timers;
-  const colors = window.__bootstrap.colors;
-  const inspectArgs = window.__bootstrap.console.inspectArgs;
-  const quoteString = window.__bootstrap.console.quoteString;
+const core = globalThis.Deno.core;
+const ops = core.ops;
+const primordials = globalThis.__bootstrap.primordials;
+const {
+  DateNow,
+  Error,
+  ErrorPrototype,
+  ObjectDefineProperties,
+  ObjectPrototypeIsPrototypeOf,
+  ObjectSetPrototypeOf,
+} = primordials;
+import * as util from "internal:zinnia_runtime/js/06_util.js";
+import * as event from "internal:deno_web/02_event.js";
+import * as timers from "internal:deno_web/02_timers.js";
+import * as colors from "internal:deno_console/01_colors.js";
+import { inspectArgs, quoteString, wrapConsole } from "internal:deno_console/02_console.js";
+import * as performance from "internal:deno_web/15_performance.js";
+import {
+  mainRuntimeGlobalProperties,
+  windowOrWorkerGlobalScope,
+} from "internal:zinnia_runtime/js/98_global_scope.js";
 
-  const { windowOrWorkerGlobalScope, mainRuntimeGlobalProperties } = window.__bootstrap.globalScope;
+function formatException(error) {
+  if (ObjectPrototypeIsPrototypeOf(ErrorPrototype, error)) {
+    return null;
+  } else if (typeof error == "string") {
+    return `Uncaught ${inspectArgs([quoteString(error)], {
+      colors: !colors.getNoColor(),
+    })}`;
+  } else {
+    return `Uncaught ${inspectArgs([error], { colors: !colors.getNoColor() })}`;
+  }
+}
 
-  function formatException(error) {
-    if (ObjectPrototypeIsPrototypeOf(ErrorPrototype, error)) {
-      return null;
-    } else if (typeof error == "string") {
-      return `Uncaught ${inspectArgs([quoteString(error)], {
-        colors: !colors.getNoColor(),
-      })}`;
-    } else {
-      return `Uncaught ${inspectArgs([error], {
-        colors: !colors.getNoColor(),
-      })}`;
-    }
+function runtimeStart(runtimeOptions) {
+  core.setMacrotaskCallback(timers.handleTimerMacrotask);
+  // core.setMacrotaskCallback(promiseRejectMacrotaskCallback);
+  // core.setWasmStreamingCallback(fetch.handleWasmStreaming);
+  // core.setReportExceptionCallback(event.reportException);
+  ops.op_set_format_exception_callback(formatException);
+  // version.setVersions(
+  //   runtimeOptions.denoVersion,
+  //   runtimeOptions.v8Version,
+  //   runtimeOptions.tsVersion,
+  // );
+  // build.setBuildInfo(runtimeOptions.target);
+  // util.setLogDebug(runtimeOptions.debugFlag, source);
+  colors.setNoColor(runtimeOptions.noColor || !runtimeOptions.isTty);
+  // deno-lint-ignore prefer-primordials
+  Error.prepareStackTrace = core.prepareStackTrace;
+}
+
+let hasBootstrapped = false;
+
+function bootstrapMainRuntime(runtimeOptions) {
+  if (hasBootstrapped) {
+    throw new Error("Worker runtime already bootstrapped");
   }
 
-  function runtimeStart(runtimeOptions) {
-    core.setMacrotaskCallback(timers.handleTimerMacrotask);
-    // core.setMacrotaskCallback(promiseRejectMacrotaskCallback);
-    // core.setWasmStreamingCallback(fetch.handleWasmStreaming);
-    // core.setReportExceptionCallback(reportException);
-    ops.op_set_format_exception_callback(formatException);
-    // version.setVersions(
-    //   runtimeOptions.denoVersion,
-    //   runtimeOptions.v8Version,
-    //   runtimeOptions.tsVersion
-    // );
-    // build.setBuildInfo(runtimeOptions.target);
-    // util.setLogDebug(runtimeOptions.debugFlag, source);
-    colors.setNoColor(runtimeOptions.noColor || !runtimeOptions.isTty);
-    // deno-lint-ignore prefer-primordials
-    Error.prepareStackTrace = core.prepareStackTrace;
-    // registerErrors();
+  performance.setTimeOrigin(DateNow());
+
+  const consoleFromV8 = globalThis.Deno.core.console;
+
+  // Remove bootstrapping data from the global scope
+  delete globalThis.__bootstrap;
+  delete globalThis.bootstrap;
+  util.log("bootstrapMainRuntime");
+  hasBootstrapped = true;
+
+  ObjectDefineProperties(globalThis, windowOrWorkerGlobalScope);
+  ObjectDefineProperties(globalThis, mainRuntimeGlobalProperties);
+  ObjectSetPrototypeOf(globalThis, Window.prototype);
+
+  if (runtimeOptions.inspectFlag) {
+    const consoleFromDeno = globalThis.console;
+    wrapConsole(consoleFromDeno, consoleFromV8);
   }
 
-  let hasBootstrapped = false;
+  event.setEventTargetData(globalThis);
+  event.saveGlobalThisReference(globalThis);
 
-  function bootstrapMainRuntime(runtimeOptions) {
-    if (hasBootstrapped) {
-      throw new Error("Worker runtime already bootstrapped");
-    }
+  runtimeStart(runtimeOptions);
 
-    core.initializeAsyncOps();
+  // delete `Deno` global
+  delete globalThis.Deno;
 
-    const consoleFromV8 = window.Deno.core.console;
-    const wrapConsole = window.__bootstrap.console.wrapConsole;
+  util.log("args", runtimeOptions.args);
+}
 
-    // Remove bootstrapping data from the global scope
-    delete globalThis.__bootstrap;
-    delete globalThis.bootstrap;
-    hasBootstrapped = true;
-
-    ObjectDefineProperties(globalThis, windowOrWorkerGlobalScope);
-    ObjectDefineProperties(globalThis, mainRuntimeGlobalProperties);
-    ObjectSetPrototypeOf(globalThis, Window.prototype);
-
-    if (runtimeOptions.inspectFlag) {
-      const consoleFromDeno = globalThis.console;
-      wrapConsole(consoleFromDeno, consoleFromV8);
-    }
-
-    eventTarget.setEventTargetData(globalThis);
-
-    runtimeStart(runtimeOptions);
-
-    // delete `Deno` global
-    delete globalThis.Deno;
-  }
-
-  ObjectDefineProperties(globalThis, {
-    bootstrap: {
-      value: {
-        mainRuntime: bootstrapMainRuntime,
-      },
-      configurable: true,
+ObjectDefineProperties(globalThis, {
+  bootstrap: {
+    value: {
+      mainRuntime: bootstrapMainRuntime,
     },
-  });
-})(this);
+    configurable: true,
+  },
+});

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -115,11 +115,11 @@ pub async fn run_js_module(
                 },
             }),
             Extension::builder("zinnia_runtime")
-                .js(include_js_files!(
-                  prefix "zinnia:runtime",
-                  "js/06_util.js",
-                  "js/98_global_scope.js",
-                  "js/99_main.js",
+                .esm(include_js_files!(
+                  dir "js",
+                  "06_util.js",
+                  "98_global_scope.js",
+                  "99_main.js",
                 ))
                 .state(move |state| {
                     state.put(ZinniaPermissions {});


### PR DESCRIPTION
Upgrade Deno crates:
- `deno_core` from `0.171.0` to `0.173.0`
- `deno_runtime` from `0.97.0` to `0.99.0`

Rework our internal modules to use the new ES module style (see https://github.com/denoland/deno/pull/17648 and and https://github.com/denoland/deno/pull/17683)

**The changes are best reviewed with whitespace-changes ignored.**

Rework the way how we call async ops - see https://github.com/denoland/deno/pull/17899

Disable Windows support for the time being because GitHub Action Windows runners don't have enough disk space for building Zinnia 😱 I opened #99 to investigate and fix this problem.

See #73