### PR TITLE
ci: fix Apple arm64 setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,13 +19,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: "x86_64-apple-darwin"
-            os: macos-latest
           - target: x86_64-apple-darwin
             os: macos-latest
-          - target: "x86_64-pc-windows-msvc"
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
             os: windows-latest
-          - target: "x86_64-unknown-linux-gnu"
+          - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Before this change, we had two matrix items with the same triple `x86_64-apple-darwin`.

This commit changes one of those items to use `aarch64-apple-darwin` instead.
