### PR TITLE
docs: update release process

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -23,9 +23,15 @@ refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
    $ cargo release --workspace --sign-tag --tag-prefix "" --execute 0.1.2
    ```
 
-1. Continue on GitHub to create a new Release:
+1. Wait for the
+   [Release CI/CD Workflow](https://github.com/filecoin-station/zinnia/actions/workflows/release.yml)
+   to finish. This usually takes about 25-30 minutes.
 
-   1. Open https://github.com/filecoin-station/zinnia/releases/new
-   1. Pick the tag created in the step above, e.g. `zinnia-v0.0.2`
-   1. Click on the button `Generate release notes`
-   1. Click on the green button `Publish release`
+1. Find the Draft Release created by the Release workflow in
+   [releases](https://github.com/filecoin-station/zinnia/releases)
+
+1. Click on the button `Generate release notes`. Review the list of commits and pick a few notable
+   ones. Add a new section `Highlights ✨` at the top of the release notes and describe the selected
+   changes.
+
+1. Click on the green button `Publish release`


### PR DESCRIPTION
Update the docs to describe the new process based on a draft release created by our Release CI/CD workflow.
