### PR TITLE
feat: upgrade Deno to 2023.03.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,9 +567,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
 ]
@@ -985,18 +985,18 @@ checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
 
 [[package]]
 name = "deno_console"
-version = "0.92.0"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55193bcb66a9a9830e1348280acbb9dd65c67d9a9a0586af9730079886408dce"
+checksum = "e7682cf8cffe4228cfed46266a343a5f7e34035f0b046d3a05afd42d60dc07c0"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.174.0"
+version = "0.175.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8077367e7e7ab2f52f1bc6285af301a1a6328b984991a3ff22236ad79862fce3"
+checksum = "cc5f1c9d721b3d634a3bbd09cc080d3e995ed411db898757c764b83c4120a36c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto"
-version = "0.106.0"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "253f0f1e66098d511f6f8c4e7bb962f6a22d602f3562acfb4ebb0740535a4e2b"
+checksum = "bffe0f20b629732e7c7bb923de0b61b3e3c67fc04263d41357070c77f83a8227"
 dependencies = [
  "aes 0.8.2",
  "aes-gcm 0.10.1",
@@ -1056,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "deno_fetch"
-version = "0.116.0"
+version = "0.117.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db67224b978271be24a60d337b96749763f70d185ac7f72897f63c51339eb00d"
+checksum = "7bc63980c0a83f4abc84e64821bf02ef5e0e1459dd2a4f0a0904660942b68ccf"
 dependencies = [
  "bytes",
  "data-url",
@@ -1075,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9d81c9e5cd9590be6043546f4565670cb6e6a7de1986fd1c354adce04eb9d4"
+checksum = "d997fae982a12cb9583add9c4ed355686c0dd988aceba9c2bfc8b0db0edc8404"
 dependencies = [
  "once_cell",
  "pmutil",
@@ -1090,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "deno_tls"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c52eea536f87f24d3c143f49f7bc11c01c95d322b781082c3d9f1dba757364"
+checksum = "7a8e788731e3b8c756a0c6641cd999184b5e179678404f4fab935b6747922e7d"
 dependencies = [
  "deno_core",
  "once_cell",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "deno_url"
-version = "0.92.0"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906895a8ba4a95f48c51a32947061bf82f42da8f7c8df787012503f1a6042685"
+checksum = "f4963b6361ae8961821e335f3939d1b893d6d0dcb637e15ac2178f8050524059"
 dependencies = [
  "deno_core",
  "serde",
@@ -1118,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.123.0"
+version = "0.124.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af75e7ff90a3f719adc074a8789da16687b9e77a97d67eb727b65fae71262637"
+checksum = "d59ff19afd843d19872634fac43ea666ca00df89e305a2afe4a51c508247f8f2"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -1134,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.92.0"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387a0cfb076580e0237ba6f1b338ee2688779c6a5e531d4a8a2a82b216917ae0"
+checksum = "9f02d35f8faae38223aedc92a4f7d16b59250f60cdcff6cea5a9f06300be2f50"
 dependencies = [
  "deno_core",
 ]
@@ -4013,9 +4013,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.85.0"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba78050262072324b0b1efba11db7367735251adf7ec734fd75780c598c743b"
+checksum = "5237fcbeda49fc0e327fc5b4d419f15851dcb50718958cd0fe31a75345694d79"
 dependencies = [
  "bytes",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/filecoin-station/zinnia"
 
 [workspace.dependencies]
 assert_fs = "1.0.11"
-deno_core = "0.174.0"
+deno_core = "0.175.0"
 log = "0.4.17"
 pretty_assertions = "1.3.0"
 env_logger = "0.10.0"

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -3,12 +3,10 @@ mod args;
 use args::{CliArgs, Commands};
 use clap::Parser;
 
-use zinnia_runtime::deno_core;
+use zinnia_runtime::anyhow::{Context, Error, Result};
+use zinnia_runtime::deno_core::error::JsError;
 use zinnia_runtime::fmt_errors::format_js_error;
-use zinnia_runtime::{colors, BootstrapOptions};
-use zinnia_runtime::{run_js_module, AnyError};
-
-use deno_core::error::JsError;
+use zinnia_runtime::{colors, resolve_path, run_js_module, BootstrapOptions};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
@@ -23,11 +21,14 @@ async fn main() {
     }
 }
 
-async fn main_impl() -> Result<(), AnyError> {
+async fn main_impl() -> Result<()> {
     let cli_args = CliArgs::parse_from(std::env::args());
     match cli_args.command {
         Commands::Run { file } => {
-            let main_module = deno_core::resolve_path(&file)?;
+            let main_module = resolve_path(
+                &file,
+                &std::env::current_dir().context("unable to get current working directory")?,
+            )?;
             let config = BootstrapOptions {
                 agent_version: format!("zinnia/{}", env!("CARGO_PKG_VERSION")),
                 ..Default::default()
@@ -38,7 +39,7 @@ async fn main_impl() -> Result<(), AnyError> {
     }
 }
 
-fn exit_with_error(error: AnyError) {
+fn exit_with_error(error: Error) {
     // Inspired by unwrap_or_exit<T> from Deno's `cli/main.rs`
     // https://github.com/denoland/deno/blob/34bfa2cb2c1f0f74a94ced8fc164e81cc91cb9f4/cli/main.rs
     let mut error_string = format!("{error:?}");

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,13 +13,13 @@ path = "lib.rs"
 
 [dependencies]
 atty = "0.2.14"
-deno_console = "0.92.0"
+deno_console = "0.93.0"
 deno_core.workspace = true
-deno_crypto = "0.106.0"
-deno_fetch = "0.116.0"
-deno_url = "0.92.0"
-deno_web = "0.123.0"
-deno_webidl = "0.92.0"
+deno_crypto = "0.107.0"
+deno_fetch = "0.117.0"
+deno_url = "0.93.0"
+deno_web = "0.124.0"
+deno_webidl = "0.93.0"
 log.workspace = true
 once_cell = "1.17.1"
 termcolor = "1.2.0"

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -7,4 +7,5 @@ mod vendored;
 pub use vendored::colors;
 pub use vendored::fmt_errors;
 
+pub use deno_core::anyhow;
 pub use deno_core::resolve_path;

--- a/runtime/tests/runtime_integration_tests.rs
+++ b/runtime/tests/runtime_integration_tests.rs
@@ -5,7 +5,7 @@
 //   deno run runtime/tests/js/timers_tests.js
 use std::path::PathBuf;
 
-use zinnia_runtime::{deno_core, run_js_module, AnyError, BootstrapOptions};
+use zinnia_runtime::{anyhow::Context, deno_core, run_js_module, AnyError, BootstrapOptions};
 
 macro_rules! js_tests(
   ( $name:ident ) => {
@@ -29,7 +29,10 @@ async fn run_js_test_file(name: &str) -> Result<(), AnyError> {
     full_path.push("js");
     full_path.push(name);
 
-    let main_module = deno_core::resolve_path(&full_path.to_string_lossy())?;
+    let main_module = deno_core::resolve_path(
+        &full_path.to_string_lossy(),
+        &std::env::current_dir().context("unable to get current working directory")?,
+    )?;
     let config = BootstrapOptions {
         agent_version: format!("zinnia_runtime_tests/{}", env!("CARGO_PKG_VERSION")),
         ..Default::default()


### PR DESCRIPTION
```
deno_core: 0.175.0
deno_console: 0.93.0
deno_crypto: 0.106.0
deno_crypto: 0.107.0
deno_fetch: 0.117.0
deno_url: 0.93.0
deno_web: 0.124.0
deno_webidl: 0.93.0
```

Release notes:
https://github.com/denoland/deno/releases/tag/v1.31.3

Notable changes:

"Upgrades bytes crate from =1.2.1 to ^1.4.0" (https://github.com/denoland/deno/pull/18123) removes another dependency version conflict preventing us from upgrading libp2p to a newer version
