### PR TITLE
feat: add `Zinnia.walletAddress` API

### DIFF
--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -201,6 +201,14 @@ for await (const chunk of response) {
 }
 ```
 
+### `Zinnia.walletAddress`
+
+The wallet address where to send rewards. When running inside the Station Desktop, this API will
+return the address of Station's built-in wallet.
+
+The value is hard-coded to a testnet address `t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za` when
+running the module via `zinnia` CLI.
+
 <!--
 UNSUPPORTED APIs
 -->

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -91,6 +91,10 @@ function bootstrapMainRuntime(runtimeOptions) {
 
   runtimeStart(runtimeOptions);
 
+  ObjectDefineProperties(globalThis.Zinnia, {
+    walletAddress: util.readOnly(runtimeOptions.walletAddress),
+  });
+
   // delete `Deno` global
   delete globalThis.Deno;
 

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -34,6 +34,9 @@ pub struct BootstrapOptions {
 
     /// Seed value for initializing the random number generator
     pub rng_seed: Option<u64>,
+
+    /// Filecoin wallet address - typically the built-in wallet in Filecoin Station
+    pub wallet_address: String,
 }
 
 impl Default for BootstrapOptions {
@@ -43,6 +46,8 @@ impl Default for BootstrapOptions {
             is_tty: colors::is_tty(),
             agent_version: format!("zinnia_runtime/{}", env!("CARGO_PKG_VERSION")),
             rng_seed: None,
+            // See https://lotus.filecoin.io/lotus/manage/manage-fil/#public-key-address
+            wallet_address: "t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za".to_owned(),
         }
     }
 }
@@ -52,6 +57,7 @@ impl BootstrapOptions {
         let payload = serde_json::json!({
           "noColor": self.no_color,
           "isTty": self.is_tty,
+          "walletAddress": self.wallet_address,
         });
         serde_json::to_string_pretty(&payload).unwrap()
     }

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -47,7 +47,7 @@ impl Default for BootstrapOptions {
             agent_version: format!("zinnia_runtime/{}", env!("CARGO_PKG_VERSION")),
             rng_seed: None,
             // See https://lotus.filecoin.io/lotus/manage/manage-fil/#public-key-address
-            wallet_address: "t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za".to_owned(),
+            wallet_address: String::from("t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za"),
         }
     }
 }

--- a/runtime/tests/js/station_apis_tests.js
+++ b/runtime/tests/js/station_apis_tests.js
@@ -1,0 +1,20 @@
+import { assertStrictEquals } from "https://deno.land/std@0.177.0/testing/asserts.ts";
+
+test("Zinnia.walletAddress", () => {
+  // Runtime JS tests are executed with the default configuration
+  // In this test, we assert that we can access the wallet address
+  // and the value is the default testnet one.
+  assertStrictEquals(Zinnia.walletAddress, "t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za");
+});
+
+// A dummy wrapper to create isolated scopes for individual tests
+// We should eventually replace this with a proper test runner
+// See https://github.com/filecoin-station/zinnia/issues/30
+function test(name, fn) {
+  try {
+    fn();
+  } catch (err) {
+    err.message = `Test ${name} failed. ` + err.message;
+    throw err;
+  }
+}

--- a/runtime/tests/runtime_integration_tests.rs
+++ b/runtime/tests/runtime_integration_tests.rs
@@ -21,6 +21,7 @@ js_tests!(timers_tests);
 js_tests!(webapis_tests);
 js_tests!(webcrypto_tests);
 js_tests!(libp2p_tests);
+js_tests!(station_apis_tests);
 
 // Run all tests in a single JS file
 async fn run_js_test_file(name: &str) -> Result<(), AnyError> {


### PR DESCRIPTION
Allow modules to access the wallet address where to send rewards.  The value is hard-coded to a testnet address for now.

When running inside the Station, this API will return the Station wallet address.

In the future, we can allow CLI users to configure this address too.

Connect to #75

