### PR TITLE
feat: APIs for reporting activity to Station

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstyle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,7 +215,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -222,7 +231,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -623,6 +632,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time 0.1.45",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "cipher"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +709,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -880,6 +914,50 @@ dependencies = [
  "platforms",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c00419335c41018365ddf7e4d5f1c12ee3659ddcf3e01974650ba1de73d038"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8307ad413a98fff033c8545ecf133e3257747b3bae935e7602aab8aa92d4ca"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.2",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc52e2eb08915cb12596d29d55f0b5384f00d697a646dbd269b6ecb0fbd9d31"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.2",
 ]
 
 [[package]]
@@ -1862,6 +1940,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows 0.46.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,7 +2016,7 @@ dependencies = [
  "rtnetlink",
  "system-configuration",
  "tokio",
- "windows",
+ "windows 0.34.0",
 ]
 
 [[package]]
@@ -2501,6 +2603,15 @@ dependencies = [
  "parking_lot 0.12.1",
  "thiserror",
  "yamux",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3477,7 +3588,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time",
+ "time 0.3.20",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -3490,7 +3601,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time",
+ "time 0.3.20",
  "yasna",
 ]
 
@@ -3799,6 +3910,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -4278,6 +4395,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
@@ -4613,6 +4741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4770,6 +4904,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -4936,7 +5076,7 @@ dependencies = [
  "sha2 0.10.6",
  "stun",
  "thiserror",
- "time",
+ "time 0.3.20",
  "tokio",
  "turn",
  "url",
@@ -5184,6 +5324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5341,7 +5490,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -5359,7 +5508,7 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -5388,7 +5537,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -5447,6 +5596,7 @@ name = "zinnia_runtime"
 version = "0.4.0"
 dependencies = [
  "atty",
+ "chrono",
  "deno_console",
  "deno_core",
  "deno_crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3633,9 +3633,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqwest"
@@ -5569,8 +5569,10 @@ dependencies = [
  "assert_fs",
  "clap",
  "env_logger",
+ "lazy_static",
  "log",
  "pretty_assertions",
+ "regex",
  "tokio",
  "zinnia_runtime",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5609,6 +5609,7 @@ dependencies = [
  "env_logger",
  "log",
  "once_cell",
+ "pretty_assertions",
  "termcolor",
  "tokio",
  "zinnia_libp2p",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,7 +24,9 @@ zinnia_runtime = { workspace = true }
 [dev-dependencies]
 assert_cmd = "2.0.10"
 assert_fs = { workspace = true }
+lazy_static = "1.4.0"
 pretty_assertions = { workspace = true }
+regex = "1.7.2"
 
 [package.metadata.winres]
 # This section defines the metadata that appears in the deno.exe PE header.

--- a/cli/tests/cli_tests.rs
+++ b/cli/tests/cli_tests.rs
@@ -31,8 +31,8 @@ Zinnia.jobCompleted();
         CmdResult {
             exit_ok: true,
             stdout: [
-                "[TIMESTAMP INFO ] information\n",
-                "[TIMESTAMP INFO ] problem\n",
+                "[TIMESTAMP  INFO] information\n",
+                "[TIMESTAMP ERROR] problem\n",
                 "[TIMESTAMP STATS] Jobs completed: 1\n",
             ]
             .join(""),

--- a/cli/tests/cli_tests.rs
+++ b/cli/tests/cli_tests.rs
@@ -76,6 +76,13 @@ function fail() {
     Ok(())
 }
 
+
+// #[test]
+// fn report_jobs_completed() -> Result<(), Box<dyn std::error::Error>> {
+//     Ok(())
+
+// }
+
 // HELPERS
 
 #[derive(PartialEq)]

--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -49,6 +49,11 @@ individual methods in [MDN web docs](https://developer.mozilla.org/en-US/docs/We
 
 - [console](https://developer.mozilla.org/en-US/docs/Web/API/console)
 
+> Note: Zinnia considers console logs as a debugging tool. All Console methods print to `stderr`.
+> See [`Zinnia.activity.info`](#zinniaactivityinfomessage) and
+> [`Zinnia.activity.error](#zinniaactivityerrormessage) APIs for reporting information to be shown
+> to Station users in the Station Desktop UI.
+
 #### DOM Standard
 
 - [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
@@ -201,13 +206,42 @@ for await (const chunk of response) {
 }
 ```
 
-### `Zinnia.walletAddress`
+#### Integration with Filecoin Station
+
+#### `Zinnia.walletAddress`
 
 The wallet address where to send rewards. When running inside the Station Desktop, this API will
 return the address of Station's built-in wallet.
 
 The value is hard-coded to a testnet address `t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za` when
 running the module via `zinnia` CLI.
+
+#### `Zinnia.activity.info(message)`
+
+Add a new Activity Log item informing the Station user when things proceed as expected.
+
+Example messages:
+
+```
+Saturn Node will try to connect to the Saturn Orchestrator...
+Saturn Node is online and connected to 9 peers.
+```
+
+#### `Zinnia.activity.error(message)`
+
+Add a new Activity Log informing the Station user about an error state.
+
+Example messages:
+
+```
+Saturn Node is not able to connect to the network.
+```
+
+#### `Zinnia.jobCompleted()`
+
+Report that a single job was completed.
+
+Call this function every time your module completes a job. It's ok to call it frequently.
 
 <!--
 UNSUPPORTED APIs

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -29,3 +29,4 @@ zinnia_libp2p.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true
+pretty_assertions = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,6 +13,7 @@ path = "lib.rs"
 
 [dependencies]
 atty = "0.2.14"
+chrono = { version= "0.4.24", features = [ "clock", "std" ] }
 deno_console = "0.93.0"
 deno_core.workspace = true
 deno_crypto = "0.107.0"

--- a/runtime/console_reporter.rs
+++ b/runtime/console_reporter.rs
@@ -1,0 +1,162 @@
+use std::cell::RefCell;
+use std::io::{stderr, stdout, Write};
+use std::time::{Duration, Instant};
+
+use crate::Reporter;
+
+#[derive(Debug)]
+pub struct JobCompletionTracker {
+    delay: Duration,
+    counter: u64,
+    last_report: Option<(Instant, u64)>,
+}
+
+impl JobCompletionTracker {
+    pub fn new(delay: Duration) -> Self {
+        Self {
+            delay,
+            counter: 0,
+            last_report: None,
+        }
+    }
+
+    pub fn job_completed<F: FnOnce(u64)>(&mut self, log: F) {
+        self.counter += 1;
+
+        if let Some(last) = self.last_report {
+            if last.0.elapsed() < self.delay {
+                return;
+            }
+        }
+        self.last_report.replace((Instant::now(), self.counter));
+
+        log(self.counter);
+    }
+
+    pub fn flush<F: FnOnce(u64)>(&mut self, log: F) {
+        match self.last_report {
+            None => {
+                // no jobs were completed, nothing to report
+            }
+            Some((_, last_total)) => {
+                if last_total != self.counter {
+                    // new jobs were completed since the last report
+                    log(self.counter);
+                }
+            }
+        }
+    }
+}
+
+/// ConsoleReporter logs activities to stdout and debug logs to stderr
+pub struct ConsoleReporter {
+    tracker: RefCell<JobCompletionTracker>,
+}
+
+impl ConsoleReporter {
+    /// Create a new instance.
+    ///
+    /// `job_report_delay` specifies how often the information about new jobs is printed.
+    pub fn new(job_report_delay: Duration) -> Self {
+        Self {
+            tracker: RefCell::new(JobCompletionTracker::new(job_report_delay)),
+        }
+    }
+
+    fn print_jobs_completed(&self, total: u64) {
+        let msg = format!("Jobs completed: {total}");
+        self.report("STATS", &msg);
+    }
+
+    fn report(&self, scope: &str, msg: &str) {
+        // Important: activity messages do not include the final newline character
+        let msg = format!("[{} {scope:>5}] {msg}\n", now_str());
+        // We are ignoring write errors because there isn't much to do in such case
+        let _ = stdout().write_all(msg.as_bytes());
+        let _ = stdout().flush();
+    }
+}
+
+impl Drop for ConsoleReporter {
+    fn drop(&mut self) {
+        self.tracker
+            .borrow_mut()
+            .flush(|n| self.print_jobs_completed(n));
+    }
+}
+
+impl Reporter for ConsoleReporter {
+    fn debug_print(&self, msg: &str) {
+        // Important: debug logs already contain the final newline character
+        // We are ignoring write errors because there isn't much to do in such case
+        let _ = stderr().write_all(msg.as_bytes());
+        let _ = stderr().flush();
+    }
+
+    fn info_activity(&self, msg: &str) {
+        self.report("INFO", msg)
+    }
+
+    fn error_activity(&self, msg: &str) {
+        self.report("ERROR", msg)
+    }
+
+    fn job_completed(&self) {
+        self.tracker
+            .borrow_mut()
+            .job_completed(|n| self.print_jobs_completed(n));
+    }
+}
+
+fn now_str() -> impl std::fmt::Display {
+    let now = chrono::Local::now();
+    now.time().format("%H:%M:%S%.3f")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl Default for JobCompletionTracker {
+        fn default() -> Self {
+            Self::new(Duration::from_millis(1000))
+        }
+    }
+
+    #[test]
+    fn tracker_prints_first_job_completion() {
+        let mut reported = 0;
+        let mut tracker = JobCompletionTracker::default();
+        tracker.job_completed(|x| reported = x);
+        assert_eq!(reported, 1);
+    }
+
+    #[test]
+    fn tracker_hides_next_job_completion() {
+        let mut reported = 0;
+        let mut tracker = JobCompletionTracker::default();
+        tracker.job_completed(|x| reported = x);
+        tracker.job_completed(|x| reported = x);
+        assert_eq!(reported, 1);
+    }
+
+    #[test]
+    fn tracker_prints_new_jobs_after_delay() {
+        let mut reported = 0;
+        let mut tracker = JobCompletionTracker::new(Duration::from_millis(1));
+        tracker.job_completed(|x| reported = x);
+        std::thread::sleep(Duration::from_millis(2));
+        tracker.job_completed(|x| reported = x);
+        assert_eq!(reported, 2);
+    }
+
+    #[test]
+    fn flush_prints_job_completion() {
+        let mut reported = 0;
+        let mut tracker = JobCompletionTracker::default();
+        tracker.job_completed(|_| ());
+        tracker.job_completed(|_| ());
+        tracker.flush(|x| reported = x);
+        assert_eq!(reported, 2);
+    }
+}

--- a/runtime/ext.rs
+++ b/runtime/ext.rs
@@ -1,0 +1,56 @@
+use std::path::Path;
+use std::rc::Rc;
+
+use deno_core::anyhow::Result;
+use deno_core::url::Url;
+use deno_core::{include_js_files, Extension};
+use deno_fetch::FetchPermissions;
+use deno_web::TimersPermission;
+
+use crate::Reporter;
+
+pub struct Options {
+    pub reporter: Rc<dyn Reporter>,
+}
+
+/// Hard-coded permissions
+pub struct ZinniaPermissions;
+
+impl TimersPermission for ZinniaPermissions {
+    fn allow_hrtime(&mut self) -> bool {
+        // Disable high-resolution time management.
+        //
+        // Quoting from https://v8.dev/docs/untrusted-code-mitigations
+        // > A high-precision timer makes it easier to observe side channels in the SSCA
+        // > vulnerability. If your product offers high-precision timers that can be accessed by
+        // > untrusted JavaScript or WebAssembly code, consider making these timers more coarse or
+        // > adding jitter to them.
+        false
+    }
+    fn check_unstable(&self, _state: &deno_core::OpState, _api_name: &'static str) {}
+}
+
+impl FetchPermissions for ZinniaPermissions {
+    fn check_net_url(&mut self, _url: &Url, _api_name: &str) -> Result<()> {
+        Ok(())
+    }
+    fn check_read(&mut self, _p: &Path, _api_name: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub fn init(options: Options) -> Extension {
+    Extension::builder("zinnia_runtime")
+        .esm(include_js_files!(
+          dir "js",
+          "06_util.js",
+          "90_zinnia_apis.js",
+          "98_global_scope.js",
+          "99_main.js",
+        ))
+        .state(move |state| {
+            state.put(ZinniaPermissions {});
+            state.put(Rc::clone(&options.reporter));
+        })
+        .build()
+}

--- a/runtime/js/90_zinnia_apis.js
+++ b/runtime/js/90_zinnia_apis.js
@@ -1,0 +1,9 @@
+const primordials = globalThis.__bootstrap.primordials;
+const { ObjectDefineProperties, ObjectCreate } = primordials;
+
+import * as libp2p from "ext:zinnia_libp2p/01_peer.js";
+
+const zinniaNs = ObjectCreate(null);
+ObjectDefineProperties(zinniaNs, libp2p.defaultPeerProps);
+
+export { zinniaNs };

--- a/runtime/js/90_zinnia_apis.js
+++ b/runtime/js/90_zinnia_apis.js
@@ -1,9 +1,42 @@
 const primordials = globalThis.__bootstrap.primordials;
 const { ObjectDefineProperties, ObjectCreate } = primordials;
 
+const { ops } = globalThis.Deno.core;
+
+import { readOnly } from "ext:zinnia_runtime/06_util.js";
 import * as libp2p from "ext:zinnia_libp2p/01_peer.js";
 
 const zinniaNs = ObjectCreate(null);
 ObjectDefineProperties(zinniaNs, libp2p.defaultPeerProps);
 
-export { zinniaNs };
+const activityApi = ObjectCreate(null);
+ObjectDefineProperties(activityApi, {
+  info: readOnly(reportInfoActivity),
+  error: readOnly(reportErrorActivity),
+});
+
+ObjectDefineProperties(zinniaNs, {
+  activity: readOnly(activityApi),
+  jobCompleted: readOnly(reportJobCompleted),
+});
+
+function reportInfoActivity(msg) {
+  if (typeof msg !== "string") msg = "" + msg;
+  ops.op_info_activity(msg);
+}
+
+function reportErrorActivity(msg) {
+  if (typeof msg !== "string") msg = "" + msg;
+  ops.op_info_activity(msg);
+}
+
+function reportJobCompleted() {
+  ops.op_job_completed();
+}
+
+function debugLog(msg) {
+  if (typeof msg !== "string") msg = "" + msg;
+  ops.op_debug_print(msg);
+}
+
+export { zinniaNs, debugLog };

--- a/runtime/js/90_zinnia_apis.js
+++ b/runtime/js/90_zinnia_apis.js
@@ -27,7 +27,7 @@ function reportInfoActivity(msg) {
 
 function reportErrorActivity(msg) {
   if (typeof msg !== "string") msg = "" + msg;
-  ops.op_info_activity(msg);
+  ops.op_error_activity(msg);
 }
 
 function reportJobCompleted() {

--- a/runtime/js/98_global_scope.js
+++ b/runtime/js/98_global_scope.js
@@ -3,8 +3,6 @@
 // https://github.com/denoland/deno/blob/86785f21194460d713276dca2/runtime/js/98_global_scope.js
 
 const core = globalThis.Deno.core;
-const primordials = globalThis.__bootstrap.primordials;
-const { ObjectDefineProperties, ObjectCreate } = primordials;
 
 import * as util from "ext:zinnia_runtime/06_util.js";
 import * as event from "ext:deno_web/02_event.js";
@@ -28,7 +26,7 @@ import * as webidl from "ext:deno_webidl/00_webidl.js";
 import DOMException from "ext:deno_web/01_dom_exception.js";
 import * as abortSignal from "ext:deno_web/03_abort_signal.js";
 import * as globalInterfaces from "ext:deno_web/04_global_interfaces.js";
-import * as libp2p from "ext:zinnia_libp2p/01_peer.js";
+import { zinniaNs } from "ext:zinnia_runtime/90_zinnia_apis.js";
 
 // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope
 const windowOrWorkerGlobalScope = {
@@ -110,9 +108,6 @@ const windowOrWorkerGlobalScope = {
   // Branding as a WebIDL object
   [webidl.brand]: util.nonEnumerable(webidl.brand),
 };
-
-const zinniaNs = ObjectCreate(null);
-ObjectDefineProperties(zinniaNs, libp2p.defaultPeerProps);
 
 const mainRuntimeGlobalProperties = {
   // Location: location.locationConstructorDescriptor,

--- a/runtime/js/98_global_scope.js
+++ b/runtime/js/98_global_scope.js
@@ -26,7 +26,7 @@ import * as webidl from "ext:deno_webidl/00_webidl.js";
 import DOMException from "ext:deno_web/01_dom_exception.js";
 import * as abortSignal from "ext:deno_web/03_abort_signal.js";
 import * as globalInterfaces from "ext:deno_web/04_global_interfaces.js";
-import { zinniaNs } from "ext:zinnia_runtime/90_zinnia_apis.js";
+import { zinniaNs, debugLog } from "ext:zinnia_runtime/90_zinnia_apis.js";
 
 // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope
 const windowOrWorkerGlobalScope = {
@@ -95,7 +95,7 @@ const windowOrWorkerGlobalScope = {
   // },
   // CacheStorage: util.nonEnumerable(caches.CacheStorage),
   // Cache: util.nonEnumerable(caches.Cache),
-  console: util.nonEnumerable(new console.Console((msg, level) => core.print(msg, level > 1))),
+  console: util.nonEnumerable(new console.Console(debugLog)),
   crypto: util.readOnly(crypto.crypto),
   Crypto: util.nonEnumerable(crypto.Crypto),
   SubtleCrypto: util.nonEnumerable(crypto.SubtleCrypto),

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -12,3 +12,6 @@ pub use deno_core::resolve_path;
 
 mod reporter;
 pub use reporter::*;
+
+mod ext;
+

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -9,3 +9,6 @@ pub use vendored::fmt_errors;
 
 pub use deno_core::anyhow;
 pub use deno_core::resolve_path;
+
+mod reporter;
+pub use reporter::*;

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -10,8 +10,9 @@ pub use vendored::fmt_errors;
 pub use deno_core::anyhow;
 pub use deno_core::resolve_path;
 
+mod console_reporter;
 mod reporter;
+pub use console_reporter::*;
 pub use reporter::*;
 
 mod ext;
-

--- a/runtime/reporter.rs
+++ b/runtime/reporter.rs
@@ -1,0 +1,154 @@
+use std::cell::RefCell;
+use std::time::{Duration, Instant};
+
+// Report events, activities and messages from the running module
+pub trait Reporter {
+    /// Print a debug log message. This is typically triggered by Console APIs like `console.log`.
+    fn debug_log(&self, msg: &str);
+
+    /// Record an activity log entry with level "info".
+    fn info_activity(&self, msg: &str);
+
+    /// Record an activity log entry with level "error".
+    fn error_activity(&self, msg: &str);
+
+    /// Report that module completed another job.
+    fn job_completed(&self);
+}
+
+const JOBS_REPORT_DELAY: Duration = Duration::from_millis(200);
+
+#[derive(Debug)]
+struct JobCompletionTracker {
+    delay: Duration,
+    counter: u64,
+    last_report: Option<(Instant, u64)>,
+}
+
+impl JobCompletionTracker {
+    pub fn new(delay: Duration) -> Self {
+        Self {
+            delay,
+            counter: 0,
+            last_report: None,
+        }
+    }
+
+    pub fn job_completed<F: FnOnce(u64) -> ()>(&mut self, log: F) {
+        self.counter += 1;
+
+        if let Some(last) = self.last_report {
+            if last.0.elapsed() < self.delay {
+                return;
+            }
+        }
+        self.last_report.replace((Instant::now(), self.counter));
+
+        log(self.counter);
+    }
+
+    pub fn flush<F: FnOnce(u64) -> ()>(&mut self, log: F) {
+        match self.last_report {
+            None => {
+                // no jobs were completed, nothing to report
+            }
+            Some((_, last_total)) => {
+                if last_total != self.counter {
+                    // new jobs were completed since the last report
+                    log(self.counter);
+                }
+            }
+        }
+    }
+}
+
+pub struct ConsoleReporter {
+    tracker: RefCell<JobCompletionTracker>,
+}
+
+impl ConsoleReporter {
+    pub fn new() -> Self {
+        Self {
+            tracker: RefCell::new(JobCompletionTracker::new(JOBS_REPORT_DELAY)),
+        }
+    }
+
+    fn print_jobs_completed(total: u64) {
+        println!("[{} STATS] Jobs completed: {}", now_str(), total);
+    }
+}
+
+impl Drop for ConsoleReporter {
+    fn drop(&mut self) {
+        self.tracker
+            .borrow_mut()
+            .flush(ConsoleReporter::print_jobs_completed);
+    }
+}
+
+impl Reporter for ConsoleReporter {
+    fn debug_log(&self, msg: &str) {
+        eprintln!("{}", msg);
+    }
+
+    fn info_activity(&self, msg: &str) {
+        println!("[{} INFO ] {msg}", now_str());
+    }
+
+    fn error_activity(&self, msg: &str) {
+        println!("[{} ERROR] {msg}", now_str());
+    }
+
+    fn job_completed(&self) {
+        self.tracker
+            .borrow_mut()
+            .job_completed(Self::print_jobs_completed);
+    }
+}
+
+fn now_str() -> impl std::fmt::Display {
+    let now = chrono::Local::now();
+    now.time().format("%H:%M:%S%.3f")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tracker_prints_first_job_completion() {
+        let mut reported = 0;
+        let mut tracker = JobCompletionTracker::new(JOBS_REPORT_DELAY);
+        tracker.job_completed(|x| reported = x);
+        assert_eq!(reported, 1);
+    }
+
+    #[test]
+    fn tracker_hides_next_job_completion() {
+        let mut reported = 0;
+        let mut tracker = JobCompletionTracker::new(JOBS_REPORT_DELAY);
+        tracker.job_completed(|x| reported = x);
+        tracker.job_completed(|x| reported = x);
+        assert_eq!(reported, 1);
+    }
+
+    #[test]
+    fn tracker_prints_new_jobs_after_delay() {
+        let mut reported = 0;
+        let mut tracker = JobCompletionTracker::new(Duration::from_millis(1));
+        tracker.job_completed(|x| reported = x);
+        std::thread::sleep(Duration::from_millis(2));
+        tracker.job_completed(|x| reported = x);
+        assert_eq!(reported, 2);
+    }
+
+    #[test]
+    fn flush_prints_job_completion() {
+        let mut reported = 0;
+        let mut tracker = JobCompletionTracker::new(JOBS_REPORT_DELAY);
+        tracker.job_completed(|_| ());
+        tracker.job_completed(|_| ());
+        tracker.flush(|x| reported = x);
+        assert_eq!(reported, 2);
+    }
+}

--- a/runtime/reporter.rs
+++ b/runtime/reporter.rs
@@ -1,6 +1,4 @@
 use std::cell::RefCell;
-use std::io::{stderr, stdout, Write};
-use std::time::{Duration, Instant};
 
 // Report events, activities and messages from the running module
 pub trait Reporter {
@@ -20,157 +18,43 @@ pub trait Reporter {
     fn job_completed(&self);
 }
 
-const JOBS_REPORT_DELAY: Duration = Duration::from_millis(200);
-
-#[derive(Debug)]
-struct JobCompletionTracker {
-    delay: Duration,
-    counter: u64,
-    last_report: Option<(Instant, u64)>,
+/// Reporter that collects all recorded events, useful for testing.
+pub struct RecordingReporter {
+    pub events: RefCell<Vec<String>>,
 }
 
-impl JobCompletionTracker {
-    pub fn new(delay: Duration) -> Self {
-        Self {
-            delay,
-            counter: 0,
-            last_report: None,
-        }
-    }
-
-    pub fn job_completed<F: FnOnce(u64)>(&mut self, log: F) {
-        self.counter += 1;
-
-        if let Some(last) = self.last_report {
-            if last.0.elapsed() < self.delay {
-                return;
-            }
-        }
-        self.last_report.replace((Instant::now(), self.counter));
-
-        log(self.counter);
-    }
-
-    pub fn flush<F: FnOnce(u64)>(&mut self, log: F) {
-        match self.last_report {
-            None => {
-                // no jobs were completed, nothing to report
-            }
-            Some((_, last_total)) => {
-                if last_total != self.counter {
-                    // new jobs were completed since the last report
-                    log(self.counter);
-                }
-            }
-        }
-    }
-}
-
-pub struct ConsoleReporter {
-    tracker: RefCell<JobCompletionTracker>,
-}
-
-impl ConsoleReporter {
+impl RecordingReporter {
     pub fn new() -> Self {
         Self {
-            tracker: RefCell::new(JobCompletionTracker::new(JOBS_REPORT_DELAY)),
+            events: RefCell::new(Vec::new()),
         }
     }
 
-    fn print_jobs_completed(&self, total: u64) {
-        let msg = format!("Jobs completed: {total}");
-        self.report("STATS", &msg);
-    }
-
-    fn report(&self, scope: &str, msg: &str) {
-        // Important: activity messages do not include the final newline character
-        let msg = format!("[{} {scope:5}] {msg}\n", now_str());
-        // We are ignoring write errors because there isn't much to do in such case
-        let _ = stdout().write_all(msg.as_bytes());
-        let _ = stdout().flush();
+    fn record(&self, event: String) {
+        self.events.borrow_mut().push(event)
     }
 }
 
-impl Default for ConsoleReporter {
+impl Default for RecordingReporter {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Drop for ConsoleReporter {
-    fn drop(&mut self) {
-        self.tracker
-            .borrow_mut()
-            .flush(|n| self.print_jobs_completed(n));
-    }
-}
-
-impl Reporter for ConsoleReporter {
+impl Reporter for RecordingReporter {
     fn debug_print(&self, msg: &str) {
-        // Important: debug logs already contain the final newline character
-        // We are ignoring write errors because there isn't much to do in such case
-        let _ = stderr().write_all(msg.as_bytes());
-        let _ = stderr().flush();
+        self.record(format!("DEBUG: {msg}"));
     }
 
     fn info_activity(&self, msg: &str) {
-        self.report("INFO", msg)
+        self.record(format!("INFO: {msg}"));
     }
 
     fn error_activity(&self, msg: &str) {
-        self.report("ERROR", msg)
+        self.record(format!("ERROR: {msg}"));
     }
 
     fn job_completed(&self) {
-        self.tracker
-            .borrow_mut()
-            .job_completed(|n| self.print_jobs_completed(n));
-    }
-}
-
-fn now_str() -> impl std::fmt::Display {
-    let now = chrono::Local::now();
-    now.time().format("%H:%M:%S%.3f")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn tracker_prints_first_job_completion() {
-        let mut reported = 0;
-        let mut tracker = JobCompletionTracker::new(JOBS_REPORT_DELAY);
-        tracker.job_completed(|x| reported = x);
-        assert_eq!(reported, 1);
-    }
-
-    #[test]
-    fn tracker_hides_next_job_completion() {
-        let mut reported = 0;
-        let mut tracker = JobCompletionTracker::new(JOBS_REPORT_DELAY);
-        tracker.job_completed(|x| reported = x);
-        tracker.job_completed(|x| reported = x);
-        assert_eq!(reported, 1);
-    }
-
-    #[test]
-    fn tracker_prints_new_jobs_after_delay() {
-        let mut reported = 0;
-        let mut tracker = JobCompletionTracker::new(Duration::from_millis(1));
-        tracker.job_completed(|x| reported = x);
-        std::thread::sleep(Duration::from_millis(2));
-        tracker.job_completed(|x| reported = x);
-        assert_eq!(reported, 2);
-    }
-
-    #[test]
-    fn flush_prints_job_completion() {
-        let mut reported = 0;
-        let mut tracker = JobCompletionTracker::new(JOBS_REPORT_DELAY);
-        tracker.job_completed(|_| ());
-        tracker.job_completed(|_| ());
-        tracker.flush(|x| reported = x);
-        assert_eq!(reported, 2);
+        self.record("JOB-COMPLETED".into());
     }
 }

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -1,12 +1,13 @@
 use std::path::Path;
 use std::rc::Rc;
+use std::time::Duration;
 
 use deno_core::anyhow::anyhow;
 use deno_core::error::type_error;
 use deno_core::futures::FutureExt;
 use deno_core::{
-    located_script_name, resolve_import, serde_json, JsRuntime, ModuleLoader,
-    ModuleSource, ModuleSourceFuture, ModuleSpecifier, ModuleType, ResolutionKind, RuntimeOptions,
+    located_script_name, resolve_import, serde_json, JsRuntime, ModuleLoader, ModuleSource,
+    ModuleSourceFuture, ModuleSpecifier, ModuleType, ResolutionKind, RuntimeOptions,
 };
 
 use deno_web::BlobStore;
@@ -44,7 +45,7 @@ pub struct BootstrapOptions {
 
 impl Default for BootstrapOptions {
     fn default() -> Self {
-        Self::new(Rc::new(ConsoleReporter::new()))
+        Self::new(Rc::new(ConsoleReporter::new(Duration::from_millis(500))))
     }
 }
 

--- a/runtime/tests/js/station_apis_tests.activity.txt
+++ b/runtime/tests/js/station_apis_tests.activity.txt
@@ -1,0 +1,5 @@
+DEBUG: debug-info
+DEBUG: debug-error
+INFO: information
+ERROR: problem
+JOB-COMPLETED

--- a/runtime/tests/js/station_apis_tests.js
+++ b/runtime/tests/js/station_apis_tests.js
@@ -7,6 +7,14 @@ test("Zinnia.walletAddress", () => {
   assertStrictEquals(Zinnia.walletAddress, "t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za");
 });
 
+test("smoke tests for reporting APIs", () => {
+  console.log("debug-info");
+  console.error("debug-error");
+  Zinnia.activity.info("information");
+  Zinnia.activity.error("problem");
+  Zinnia.jobCompleted();
+});
+
 // A dummy wrapper to create isolated scopes for individual tests
 // We should eventually replace this with a proper test runner
 // See https://github.com/filecoin-station/zinnia/issues/30

--- a/runtime/tests/runtime_integration_tests.rs
+++ b/runtime/tests/runtime_integration_tests.rs
@@ -4,14 +4,28 @@
 // Most of the tests should pass on Deno too!
 //   deno run runtime/tests/js/timers_tests.js
 use std::path::PathBuf;
+use std::rc::Rc;
 
+use zinnia_runtime::RecordingReporter;
 use zinnia_runtime::{anyhow::Context, deno_core, run_js_module, AnyError, BootstrapOptions};
+
+use pretty_assertions::assert_eq;
 
 macro_rules! js_tests(
   ( $name:ident ) => {
     #[tokio::test]
     async fn $name() -> Result<(), AnyError> {
-      run_js_test_file(&format!("{}.js", stringify!($name))).await
+      run_js_test_file(&format!("{}.js", stringify!($name)), None).await
+  }
+  };
+
+  ( $name:ident check_activity) => {
+    #[tokio::test]
+    async fn $name() -> Result<(), AnyError> {
+      run_js_test_file(
+        &format!("{}.js", stringify!($name)),
+        Some(&format!("{}.activity.txt", stringify!($name))),
+      ).await
   }
   };
 );
@@ -21,24 +35,46 @@ js_tests!(timers_tests);
 js_tests!(webapis_tests);
 js_tests!(webcrypto_tests);
 js_tests!(libp2p_tests);
-js_tests!(station_apis_tests);
+js_tests!(station_apis_tests check_activity);
 
 // Run all tests in a single JS file
-async fn run_js_test_file(name: &str) -> Result<(), AnyError> {
-    let mut full_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    full_path.push("tests");
-    full_path.push("js");
+async fn run_js_test_file(name: &str, activity_log: Option<&str>) -> Result<(), AnyError> {
+    let mut base_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    base_dir.push("tests");
+    base_dir.push("js");
+
+    let mut full_path = base_dir.clone();
     full_path.push(name);
 
     let main_module = deno_core::resolve_path(
         &full_path.to_string_lossy(),
         &std::env::current_dir().context("unable to get current working directory")?,
     )?;
+    let reporter = Rc::new(RecordingReporter::new());
     let config = BootstrapOptions {
         agent_version: format!("zinnia_runtime_tests/{}", env!("CARGO_PKG_VERSION")),
+        reporter: reporter.clone(),
         ..Default::default()
     };
     run_js_module(&main_module, &config).await?;
+
+    if let Some(log_file) = activity_log {
+        let mut activity_path = base_dir.clone();
+        activity_path.push(log_file);
+        let expected_text = std::fs::read_to_string(activity_path.clone())
+            .with_context(|| format!("cannot read {}", activity_path.display()))?;
+
+        assert_eq!(
+            reporter
+                .events
+                .borrow()
+                .iter()
+                .map(|e| format!("{}\n", e.trim_end()))
+                .collect::<Vec<String>>()
+                .join(""),
+            expected_text,
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Implement the following new APIs:

```ts
namespace Zinnia {
   // omitted: existing APIs like `peerId` and `walletAddress`

   /** Report activities to the Station. These messages are displayed in the main UI. */
   activity: {
     /** Report an informative status update, e.g. "Connecting to the network." */
     info(message: string);

     /** Report an error, e.g. "Cannot connect to the orchestrator." */
     error(message: string);
   }

   /** Report completion of a single job */
   jobCompleted();
 }
```

Rework the implementation of `Console` APIs to treat all logs as debug logs and print them to `stderr`, regardless of their severity.

See #75 and #121.