### PR TITLE
feat: upgrade Deno to 2023.03.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,18 +951,18 @@ checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
 
 [[package]]
 name = "deno_console"
-version = "0.93.0"
+version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7682cf8cffe4228cfed46266a343a5f7e34035f0b046d3a05afd42d60dc07c0"
+checksum = "090d1bc92e07cd56a3cc46e92c5bb511670863451d31ab9428ddb4d206ca7dbf"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.175.0"
+version = "0.176.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5f1c9d721b3d634a3bbd09cc080d3e995ed411db898757c764b83c4120a36c"
+checksum = "1bc66d4e7acc630bd2f8ca633d4028e40e96716d2fa3b6e5f8aec05c4077b7a8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -985,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto"
-version = "0.107.0"
+version = "0.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffe0f20b629732e7c7bb923de0b61b3e3c67fc04263d41357070c77f83a8227"
+checksum = "237a878a66370607275d3e803ae5a23845df9c9821878e2fd07bdd83a4fec192"
 dependencies = [
  "aes 0.8.2",
  "aes-gcm 0.10.1",
@@ -1022,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "deno_fetch"
-version = "0.117.0"
+version = "0.118.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc63980c0a83f4abc84e64821bf02ef5e0e1459dd2a4f0a0904660942b68ccf"
+checksum = "cbc2674ebf34483faa15dcb39a766518686d3cf6f8e2757f95b677aa11bb7842"
 dependencies = [
  "bytes",
  "data-url",
@@ -1041,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d997fae982a12cb9583add9c4ed355686c0dd988aceba9c2bfc8b0db0edc8404"
+checksum = "379db8f7ed565fed24ab7f390c5a087fc17e2cce3a3dd700072eaa19070a572e"
 dependencies = [
  "once_cell",
  "pmutil",
@@ -1056,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "deno_tls"
-version = "0.80.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8e788731e3b8c756a0c6641cd999184b5e179678404f4fab935b6747922e7d"
+checksum = "144860a469009fb4efa516b3cc015dbc26604f64efaf34600e565bcca0c7687e"
 dependencies = [
  "deno_core",
  "once_cell",
@@ -1072,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "deno_url"
-version = "0.93.0"
+version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4963b6361ae8961821e335f3939d1b893d6d0dcb637e15ac2178f8050524059"
+checksum = "6da119753458988ae19a59e2c81b19c4334058a3e8b3561e8d46602f8973c3cc"
 dependencies = [
  "deno_core",
  "serde",
@@ -1084,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.124.0"
+version = "0.125.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ff19afd843d19872634fac43ea666ca00df89e305a2afe4a51c508247f8f2"
+checksum = "dd3da4135f9e1f1f39a3a0b897aa80eaf7b369f23a27154ec8cd9913b45bc985"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -1100,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.93.0"
+version = "0.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02d35f8faae38223aedc92a4f7d16b59250f60cdcff6cea5a9f06300be2f50"
+checksum = "0d82fc48c65de1390dfc6d1b97aee5159cb718a3d1be01c9e91c9c9535294fa6"
 dependencies = [
  "deno_core",
 ]
@@ -1786,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -3965,12 +3965,13 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.86.0"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5237fcbeda49fc0e327fc5b4d419f15851dcb50718958cd0fe31a75345694d79"
+checksum = "8238c4ed559ceef926714cf63108d76eaeac90cd18b22935dbc5dd9fd8c67618"
 dependencies = [
  "bytes",
  "derive_more",
+ "num-bigint",
  "serde",
  "serde_bytes",
  "smallvec",
@@ -4693,9 +4694,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.64.0"
+version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2287b485fa902172da3722d7e557e083afd63921777e0c6e5c0fba28e6d59d3"
+checksum = "6c8ab8597b885c17b3761f6ffc29b7a62758612c409285a9271c6dacd17bb745"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/filecoin-station/zinnia"
 
 [workspace.dependencies]
 assert_fs = "1.0.12"
-deno_core = "0.175.0"
+deno_core = "0.176.0"
 log = "0.4.17"
 pretty_assertions = "1.3.0"
 env_logger = "0.10.0"

--- a/ext/libp2p/lib.rs
+++ b/ext/libp2p/lib.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use deno_core::anyhow::{anyhow, Context, Result};
 use deno_core::error::AnyError;
-use deno_core::{include_js_files, op, Extension, OpState, ZeroCopyBuf};
+use deno_core::{op, OpState, ZeroCopyBuf};
 use libp2p::identity::PeerId;
 use libp2p::multiaddr::Protocol;
 use libp2p::Multiaddr;
@@ -22,26 +22,27 @@ pub struct Options {
 #[derive(Debug, Clone, Copy)]
 struct DefaultNodeResourceId(deno_core::ResourceId);
 
-pub fn init(options: Options) -> Extension {
-    Extension::builder(env!("CARGO_PKG_NAME"))
-        .esm(include_js_files!(
-            dir "js",
-             "01_peer.js",
-        ))
-        .ops(vec![
-            op_p2p_get_peer_id::decl(),
-            op_p2p_request_protocol::decl(),
-        ])
-        .state(move |state| {
-            let default_node = PeerNode::spawn(options.default_peer.clone())
-                // FIXME: map errors to AnyError instead of panicking
-                // We need to convert `Box<dyn Error + Send>` to `anyhow::Error`
-                .unwrap();
-            let rid = state.resource_table.add(default_node);
-            state.put::<DefaultNodeResourceId>(DefaultNodeResourceId(rid));
-        })
-        .build()
-}
+deno_core::extension!(zinnia_libp2p,
+    ops = [
+        op_p2p_get_peer_id,
+        op_p2p_request_protocol,
+    ],
+    esm = [
+        dir "js",
+        "01_peer.js",
+    ],
+    options = {
+        default_peer: PeerNodeConfig,
+    },
+    state = |state, options| {
+        let default_node = PeerNode::spawn(options.default_peer)
+            // FIXME: map errors to AnyError instead of panicking
+            // We need to convert `Box<dyn Error + Send>` to `anyhow::Error`
+            .unwrap();
+        let rid = state.resource_table.add(default_node);
+        state.put::<DefaultNodeResourceId>(DefaultNodeResourceId(rid));
+    },
+);
 
 #[op]
 pub fn op_p2p_get_peer_id(state: &mut OpState) -> Result<String> {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,13 +13,13 @@ path = "lib.rs"
 
 [dependencies]
 atty = "0.2.14"
-deno_console = "0.93.0"
+deno_console = "0.94.0"
 deno_core.workspace = true
-deno_crypto = "0.107.0"
-deno_fetch = "0.117.0"
-deno_url = "0.93.0"
-deno_web = "0.124.0"
-deno_webidl = "0.93.0"
+deno_crypto = "0.108.0"
+deno_fetch = "0.118.0"
+deno_url = "0.94.0"
+deno_web = "0.125.0"
+deno_webidl = "0.94.0"
 log.workspace = true
 once_cell = "1.17.1"
 termcolor = "1.2.0"

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -99,24 +99,23 @@ pub async fn run_js_module(
     let mut runtime = JsRuntime::new(RuntimeOptions {
         extensions: vec![
             // Web Platform APIs implemented by Deno
-            deno_console::init_esm(),
-            deno_webidl::init_esm(),
-            deno_url::init_ops_and_esm(),
-            deno_web::init_ops_and_esm::<ZinniaPermissions>(
+            deno_console::deno_console::init_ops_and_esm(),
+            deno_webidl::deno_webidl::init_ops_and_esm(),
+            deno_url::deno_url::init_ops_and_esm(),
+            deno_web::deno_web::init_ops_and_esm::<ZinniaPermissions>(
                 blob_store,
                 Some(module_specifier.clone()),
             ),
-            deno_fetch::init_ops_and_esm::<ZinniaPermissions>(Default::default()),
-            deno_crypto::init_ops_and_esm(bootstrap_options.rng_seed),
+            deno_fetch::deno_fetch::init_ops_and_esm::<ZinniaPermissions>(Default::default()),
+            deno_crypto::deno_crypto::init_ops_and_esm(bootstrap_options.rng_seed),
             // Zinnia-specific APIs
-            zinnia_libp2p::init(zinnia_libp2p::Options {
-                default_peer: zinnia_libp2p::PeerNodeConfig {
-                    agent_version: bootstrap_options.agent_version.clone(),
-                    ..Default::default()
-                },
+            zinnia_libp2p::zinnia_libp2p::init_ops_and_esm(zinnia_libp2p::PeerNodeConfig {
+                agent_version: bootstrap_options.agent_version.clone(),
+                ..Default::default()
             }),
             Extension::builder("zinnia_runtime")
                 .esm(include_js_files!(
+                  zinnia_runtime
                   dir "js",
                   "06_util.js",
                   "98_global_scope.js",
@@ -136,7 +135,7 @@ pub async fn run_js_module(
     });
 
     let script = format!("bootstrap.mainRuntime({})", bootstrap_options.as_json());
-    runtime.execute_script(&located_script_name!(), &script)?;
+    runtime.execute_script(located_script_name!(), script)?;
 
     // Load and run the module
     let main_module_id = runtime.load_main_module(module_specifier, None).await?;
@@ -205,7 +204,7 @@ impl ModuleLoader for ZinniaModuleLoader {
             };
 
             let module = ModuleSource {
-                code: Box::from(code.as_bytes()),
+                code: code.into(),
                 module_type: ModuleType::JavaScript,
                 module_url_specified: specifier.to_string(),
                 module_url_found: specifier.to_string(),


### PR DESCRIPTION
Relevant changes:
- [feat(core): deno\_core::extension! macro to simplify extension registration]( https://github.com/denoland/deno/pull/18210)
- [feat(ext/url): URLSearchParams.size](https://github.com/denoland/deno/pull/17884)
- [feat(serde\_v8): support BigInt serialization]( https://github.com/denoland/deno/pull/18225)
- fix(runtime): Extract error code for all OS error variants
- [perf(core) Reduce copying and cloning in extension initialization]( https://github.com/denoland/deno/pull/18252)
- [perf(core) Reduce script name and script code copies]( https://github.com/denoland/deno/pull/18298)
- perf(core): preserve ops between snapshots
- perf(core): use static specifier in ExtensionFileSource
- perf: disable WAL for transpiled source cache
- perf: disable runtime snapshot compression

Full changelog:
https://github.com/denoland/deno/blob/v1.32.0/Releases.md#1320--20230322
