### PR TITLE
feat: `zinniad` for Filecoin Station

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5599,6 +5599,8 @@ dependencies = [
  "env_logger",
  "log",
  "pretty_assertions",
+ "serde",
+ "serde_json",
  "tokio",
  "zinnia_runtime",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5590,3 +5590,15 @@ dependencies = [
  "tokio",
  "zinnia_libp2p",
 ]
+
+[[package]]
+name = "zinniad"
+version = "0.5.0"
+dependencies = [
+ "clap",
+ "env_logger",
+ "log",
+ "pretty_assertions",
+ "tokio",
+ "zinnia_runtime",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
 
     "runtime",
     "cli",
+    "daemon",
 ]
 
 [workspace.package]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -17,6 +17,8 @@ doc = false
 clap = { version = "4.1.13", features = ["derive", "env"] }
 env_logger.workspace = true
 log.workspace = true
+serde.workspace = true
+serde_json = "1.0.94"
 tokio = { workspace = true }
 zinnia_runtime = { workspace = true }
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "zinniad"
+version = "0.5.0"
+authors.workspace = true
+default-run = "zinniad"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Zinnia daemon runs Zinnia modules inside Filecoin Station."
+
+[[bin]]
+name = "zinniad"
+path = "main.rs"
+doc = false
+
+[dependencies]
+clap = { version = "4.1.13", features = ["derive", "env"] }
+env_logger.workspace = true
+log.workspace = true
+tokio = { workspace = true }
+zinnia_runtime = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }

--- a/daemon/args.rs
+++ b/daemon/args.rs
@@ -28,6 +28,10 @@ pub enum Commands {
     },
 }
 
+// TODO: replace platform-specific code with https://crates.io/crates/directories
+// We need to contribute support for `state_dir` on Windows & MacOS
+// https://github.com/dirs-dev/directories-rs/issues/70
+
 #[cfg(target_os = "macos")]
 fn get_default_root_dir<'a, F>(get_env_var: F) -> String
 where

--- a/daemon/args.rs
+++ b/daemon/args.rs
@@ -1,0 +1,124 @@
+use std::env;
+
+use clap::{command, Parser, Subcommand};
+
+#[derive(Parser, PartialEq, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct CliArgs {
+    /// Address of Station's built-in wallet (required).
+    #[arg(long, short = 'w', env)]
+    pub wallet_address: String,
+
+    /// Directory where to keep state files (optional). Defaults to a platform-specific location,
+    /// e.g. $XDG_STATE_HOME/zinniad on Linux.
+    #[arg(long, short = 'r', env, default_value_t = get_default_root_dir(env::var))]
+    pub root_dir: String,
+
+    /// List of modules to run, where each module is a single JS file. We don't make any assumptions
+    /// about the directory layout of modules. Paths are resolved relatively to the current working
+    /// directory.
+    pub files: Vec<String>,
+}
+
+#[derive(Subcommand, PartialEq, Debug)]
+pub enum Commands {
+    Run {
+        /// JavaScript file containing the Station Module to run
+        file: String,
+    },
+}
+
+#[cfg(target_os = "macos")]
+fn get_default_root_dir<'a, F>(get_env_var: F) -> String
+where
+    F: Fn(&'a str) -> Result<String, env::VarError>,
+{
+    let home = get_env_var("HOME").expect("HOME must be set");
+    format!("{home}/Library/Application Support/app.filstation.zinniad")
+}
+
+#[cfg(target_os = "linux")]
+fn get_default_root_dir<'a, F>(get_env_var: F) -> String
+where
+    F: Fn(&'a str) -> Result<String, env::VarError>,
+{
+    match get_env_var("XDG_STATE_HOME") {
+        Ok(state_home) => format!("{state_home}/zinniad"),
+        Err(_) => {
+            let home = get_env_var("HOME").expect("HOME must be set");
+            format!("{home}/Library/Application Support/app.filstation.zinniad")
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn get_default_root_dir<'a, F>(get_env_var: F) -> String
+where
+    F: Fn(&'a str) -> Result<String, env::VarError>,
+{
+    let app_data = get_env_var("LOCALAPPDATA").expect("LOCALAPPDATA must be set");
+    format!("{app_data}/zinniad")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn default_root_dir_on_macos() {
+        let env = HashMap::from([("HOME", "/users/labber")]);
+        let dir = get_default_root_dir(|key| {
+            env.get(&key)
+                .map(|val| String::from(*val))
+                .ok_or(env::VarError::NotPresent)
+        });
+
+        assert_eq!(
+            dir,
+            "/users/labber/Library/Application Support/app.filstation.zinniad"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn default_root_dir_on_linux() {
+        let env = HashMap::from([("XDG_STATE_HOME", "/users/labber/.local-state")]);
+        let dir = get_default_root_dir(|key| {
+            env.get(&key)
+                .map(|val| String::from(*val))
+                .ok_or(env::VarError::NotPresent)
+        });
+
+        assert_eq!(dir, "/users/labber/.local-state/zinniad");
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn default_root_dir_on_linux_without_xdg() {
+        let env = HashMap::from([("HOME", "/users/labber")]);
+        let dir = get_default_root_dir(|key| {
+            env.get(&key)
+                .map(|val| String::from(*val))
+                .ok_or(env::VarError::NotPresent)
+        });
+
+        assert_eq!(dir, "/users/labber/.local/state/zinniad");
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn default_root_dir_on_linux() {
+        let env = HashMap::from([("LOCALAPPDATA", r"\Users\Jane Smith\AppData\Local")]);
+        let dir = get_default_root_dir(|key| {
+            env.get(&key)
+                .map(|val| String::from(*val))
+                .ok_or(env::VarError::NotPresent)
+        });
+
+        assert_eq!(dir, r"\Users\Jane Smith\AppData\Local\Zinnia Service");
+    }
+}

--- a/daemon/args.rs
+++ b/daemon/args.rs
@@ -61,7 +61,7 @@ where
     F: Fn(&'a str) -> Result<String, env::VarError>,
 {
     let app_data = get_env_var("LOCALAPPDATA").expect("LOCALAPPDATA must be set");
-    format!("{app_data}/zinniad")
+    format!("{app_data}\\zinniad")
 }
 
 #[cfg(test)]
@@ -123,6 +123,6 @@ mod tests {
                 .ok_or(env::VarError::NotPresent)
         });
 
-        assert_eq!(dir, r"\Users\Jane Smith\AppData\Local\Zinnia Service");
+        assert_eq!(dir, r"\Users\Jane Smith\AppData\Local\zinniad");
     }
 }

--- a/daemon/args.rs
+++ b/daemon/args.rs
@@ -50,7 +50,7 @@ where
         Ok(state_home) => format!("{state_home}/zinniad"),
         Err(_) => {
             let home = get_env_var("HOME").expect("HOME must be set");
-            format!("{home}/Library/Application Support/app.filstation.zinniad")
+            format!("{home}/.local/state/zinniad")
         }
     }
 }

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -1,4 +1,8 @@
 mod args;
+mod station_reporter;
+
+use std::rc::Rc;
+use std::time::Duration;
 
 use args::CliArgs;
 use clap::Parser;
@@ -6,6 +10,8 @@ use clap::Parser;
 use log::{error, info};
 use zinnia_runtime::anyhow::{anyhow, Context, Error, Result};
 use zinnia_runtime::{resolve_path, run_js_module, BootstrapOptions};
+
+use crate::station_reporter::StationReporter;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
@@ -46,6 +52,10 @@ async fn run(config: CliArgs) -> Result<()> {
             env!("CARGO_PKG_VERSION")
         ),
         wallet_address: config.wallet_address,
+        reporter: Rc::new(StationReporter::new(
+            Duration::from_millis(200),
+            module_name.into(),
+        )),
         ..Default::default()
     };
 

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -1,0 +1,49 @@
+mod args;
+
+use args::CliArgs;
+use clap::Parser;
+
+use log::{error, info};
+use zinnia_runtime::anyhow::{anyhow, Error, Result};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    setup_logger();
+    let cli_args = CliArgs::parse_from(std::env::args());
+
+    match run(cli_args).await {
+        Ok(_) => (),
+        Err(err) => exit_with_error(err),
+    }
+}
+
+async fn run(config: CliArgs) -> Result<()> {
+    info!("Starting zinniad with config {config:?}");
+
+    if config.files.is_empty() {
+        return Err(anyhow!("You must provide at least one module to run."));
+    }
+    if config.files.len() > 1 {
+        return Err(anyhow!(
+            "zinniad does not yet support running more than one module."
+        ));
+    }
+
+    info!("To be done: run {}", config.files[0]);
+    Ok(())
+}
+
+fn setup_logger() {
+    let mut builder = env_logger::Builder::new();
+    builder.filter_level(log::LevelFilter::Info);
+    builder.parse_default_env();
+    builder.init();
+}
+
+fn exit_with_error(error: Error) {
+    let error_string = format!("{error:?}");
+    let error_code = 1;
+
+    error!("{}", error_string.trim_start_matches("error: "));
+    std::process::exit(error_code);
+}

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -11,7 +11,7 @@ use log::{error, info};
 use zinnia_runtime::anyhow::{anyhow, Context, Error, Result};
 use zinnia_runtime::{resolve_path, run_js_module, BootstrapOptions};
 
-use crate::station_reporter::StationReporter;
+use crate::station_reporter::{log_info_activity, StationReporter};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
@@ -35,6 +35,9 @@ async fn run(config: CliArgs) -> Result<()> {
             "We do not yet support running more than one module."
         ));
     }
+
+    log_info_activity("Module Runtime started.");
+
     let file = &config.files[0];
 
     // TODO: configurable module name and version
@@ -61,6 +64,7 @@ async fn run(config: CliArgs) -> Result<()> {
 
     // TODO: handle module exit and restart it
     // https://github.com/filecoin-station/zinnia/issues/146
+    log::info!("Starting module {main_module}");
     run_js_module(&main_module, &config).await?;
 
     Ok(())

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -46,7 +46,7 @@ async fn run(config: CliArgs) -> Result<()> {
     let module_version = "unknown";
 
     let main_module = resolve_path(
-        &file,
+        file,
         &std::env::current_dir().context("unable to get current working directory")?,
     )?;
     let config = BootstrapOptions {

--- a/daemon/station_reporter.rs
+++ b/daemon/station_reporter.rs
@@ -1,0 +1,97 @@
+use std::cell::RefCell;
+use std::io::{stderr, stdout, Write};
+use std::time::Duration;
+
+use serde_json::{json, Map};
+use zinnia_runtime::anyhow::Result;
+use zinnia_runtime::{JobCompletionTracker, LogLevel, Reporter};
+
+/// StationReporter reports activities to stdout as ND-JSON stream and all Console logs to stderr
+pub struct StationReporter {
+    tracker: RefCell<JobCompletionTracker>,
+    module_name: String,
+    log_target: String,
+}
+
+impl StationReporter {
+    /// Create a new instance.
+    ///
+    /// `job_report_delay` specifies how often the information about new jobs is printed.
+    pub fn new(job_report_delay: Duration, module_name: String) -> Self {
+        let log_target = format!("module:{module_name}");
+        Self {
+            tracker: RefCell::new(JobCompletionTracker::new(job_report_delay)),
+            module_name,
+            log_target,
+        }
+    }
+
+    fn print_jobs_completed(&self, total: u64) {
+        // TODO: print data from all modules
+        // https://github.com/filecoin-station/zinnia/issues/144
+        // modules: {"saturn": 100, "retrieval-checker": 23}}
+        let mut modules = Map::new();
+        modules.insert(self.module_name.clone(), json!(total));
+
+        let event = json!({
+            "type": "jobs-completed",
+            "total": total,
+             "modules": modules,
+        });
+
+        let _ = print_event(&event);
+        // ^^^ We are ignoring errors because there isn't much to do in such case
+    }
+}
+
+fn print_event(data: &serde_json::Value) -> Result<()> {
+    // serde_json::to_writer(stdout(), data)?;
+    writeln!(stdout(), "{data}")?;
+    stdout().flush()?;
+    Ok(())
+}
+
+impl Drop for StationReporter {
+    fn drop(&mut self) {
+        self.tracker
+            .borrow_mut()
+            .flush(|n| self.print_jobs_completed(n));
+    }
+}
+
+impl Reporter for StationReporter {
+    fn log(&self, level: LogLevel, msg: &str) {
+        // Important: Console logs already contain the final newline character
+        // We print all Console logs to stderr, because stdout is reserved for activity events
+        // We are ignoring write errors because there isn't much to do in such case
+        log::log!(target: &self.log_target, level.into(), "{}", msg.trim_end());
+        // let _ = write!(stderr(), "[{level:>5}] {msg}");
+        let _ = stderr().flush();
+    }
+
+    fn info_activity(&self, msg: &str) {
+        let event = json!({
+            "type": "activity:info",
+            "module": self.module_name,
+            "message": msg,
+        });
+        let _ = print_event(&event);
+        // ^^^ We are ignoring errors because there isn't much to do in such case
+    }
+
+    fn error_activity(&self, msg: &str) {
+        let event = json!({
+            "type": "activity:error",
+            "module": self.module_name,
+            "message": msg,
+        });
+        let _ = print_event(&event);
+        // ^^^ We are ignoring errors because there isn't much to do in such case
+    }
+
+    fn job_completed(&self) {
+        self.tracker
+            .borrow_mut()
+            .job_completed(|n| self.print_jobs_completed(n));
+    }
+}

--- a/daemon/station_reporter.rs
+++ b/daemon/station_reporter.rs
@@ -45,10 +45,30 @@ impl StationReporter {
 }
 
 fn print_event(data: &serde_json::Value) -> Result<()> {
-    // serde_json::to_writer(stdout(), data)?;
     writeln!(stdout(), "{data}")?;
     stdout().flush()?;
     Ok(())
+}
+
+pub fn log_info_activity(msg: &str) {
+    let event = json!({
+        "type": "activity:info",
+        "module": serde_json::Value::Null,
+        "message": msg,
+    });
+    let _ = print_event(&event);
+    // ^^^ We are ignoring errors because there isn't much to do in such case
+}
+
+#[allow(unused)]
+pub fn log_error_activity(msg: &str) {
+    let event = json!({
+        "type": "activity:error",
+        "module": serde_json::Value::Null,
+        "message": msg,
+    });
+    let _ = print_event(&event);
+    // ^^^ We are ignoring errors because there isn't much to do in such case
 }
 
 impl Drop for StationReporter {

--- a/runtime/reporter.rs
+++ b/runtime/reporter.rs
@@ -24,6 +24,17 @@ impl Display for LogLevel {
     }
 }
 
+impl From<LogLevel> for log::Level {
+    fn from(value: LogLevel) -> Self {
+        match value {
+            LogLevel::Debug => log::Level::Debug,
+            LogLevel::Info => log::Level::Info,
+            LogLevel::Warn => log::Level::Warn,
+            LogLevel::Error => log::Level::Error,
+        }
+    }
+}
+
 // Report events, activities and messages from the running module
 pub trait Reporter {
     /// Print a debug log message. This is typically triggered by Console APIs like `console.log`.


### PR DESCRIPTION
Implement a new binary `zinniad` that can run multiple modules at the same time and acts as another Filecoin Station Module.

See #75 

## Out of Scope

- #142
- #143
- #144
- #145
- #146
- #147
- #148

## Usage

```
❯ zinniad --help
Zinnia daemon runs Zinnia modules inside Filecoin Station.

Usage: zinniad [OPTIONS] --wallet-address <WALLET_ADDRESS> [FILES]...

Arguments:
  [FILES]...  List of modules to run, where each module is a single JS file. We don't make any assumptions about the directory layout of modules. Paths are resolved relatively to the current working directory

Options:
  -w, --wallet-address <WALLET_ADDRESS>
          Address of Station's built-in wallet (required) [env: WALLET_ADDRESS=]
  -r, --root-dir <ROOT_DIR>
          Directory where to keep state files (optional). Defaults to a platform-specific location, e.g. $XDG_STATE_HOME/zinniad on Linux [env: ROOT_DIR=] [default: "/Users/bajtos/Library/Application Support/app.filstation.zinniad"]
  -h, --help
          Print help
  -V, --version
          Print version
```

## In Action

<img width="948" alt="Screenshot 2023-03-27 at 17 47 46" src="https://user-images.githubusercontent.com/1140553/227994146-a32d9e3e-d3ee-458f-8558-9612eb5e0064.png">

Raw stdout (ND-JSON):

```text
❯ cargo run -p zinniad -- -w f1asd ping-probe.js 2>/dev/null
{"type":"activity:info","module":null,"message":"Module Runtime started."}
{"type":"jobs-completed","total":1,"modules":{"ping-probe":1}}
{"type":"jobs-completed","total":2,"modules":{"ping-probe":2}}
```

Raw stderr - notice that Console logs are printed via Rust logging API, annotated with module name and timestamp:

```text
❯ NO_COLOR=1 cargo run -p zinniad -- -w f1asd ping-probe.js >/dev/null
    Finished dev [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/zinniad -w f1asd ping-probe.js`
[2023-03-27T15:50:18Z INFO  zinniad] Starting zinniad with config CliArgs { wallet_address: "f1asd", root_dir: "/Users/bajtos/Library/Application Support/app.filstation.zinniad", files: ["ping-probe.js"] }
[2023-03-27T15:50:18Z INFO  zinniad] Starting module file:///Users/bajtos/src/zinnia/zinnia/ping-probe.js
[2023-03-27T15:50:18Z INFO  module:ping-probe] Pinging /dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb
[2023-03-27T15:50:19Z INFO  module:ping-probe] RTT: 518ms
[2023-03-27T15:50:19Z INFO  module:ping-probe] Submitted stats to InfluxDB.
[2023-03-27T15:50:20Z INFO  module:ping-probe] Pinging /dns/saturn-link-poc.fly.dev/tcp/3030/p2p/12D3KooWRH71QRJe5vrMp6zZXoH4K7z5MDSWwTXXPriG9dK8HQXk
[2023-03-27T15:50:20Z INFO  module:ping-probe] RTT: 538ms
[2023-03-27T15:50:21Z INFO  module:ping-probe] Submitted stats to InfluxDB.
```