### PR TITLE
ci: run tests on macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,11 +60,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Should we run the tests on macOS too?
-          # - target: "x86_64-apple-darwin"
-          #   os: macos-latest
-          # - target: aarch64-apple-darwin
-          #   os: macos-latest
+          - target: "x86_64-apple-darwin"
+            os: macos-latest
           - target: "x86_64-pc-windows-msvc"
             os: windows-latest
           - target: "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
We have platform-specific code in `zinniad` that should be tested on macOS too.

See #75
