### PR TITLE
feat: notarize macOS binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
           # Sign `zinnia`
           codesign --timestamp --force --verbose \
             --options runtime \
+            --entitlements build/entitlements.mac.plist \
             --sign "$MACOS_SIGNING_IDENTITY" \
             --identifier "$MACOS_APP_ID" \
             target/${{ matrix.target }}/release/zinnia
@@ -122,6 +123,7 @@ jobs:
           # Sign `zinniad`
           codesign --timestamp --force --verbose \
             --options runtime \
+            --entitlements build/entitlements.mac.plist \
             --sign "$MACOS_SIGNING_IDENTITY" \
             --identifier "$MACOS_APP_ID" \
             target/${{ matrix.target }}/release/zinniad

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
-  MACOSX_DEPLOYMENT_TARGET: 10.7
+  MACOSX_DEPLOYMENT_TARGET: 10.9
   # Emit backtraces on panics.
   RUST_BACKTRACE: 1
 
@@ -101,7 +101,7 @@ jobs:
           tar czvf ../../../zinnia-${{ matrix.name }} zinnia
           tar czvf ../../../zinniad-${{ matrix.name }} zinniad
 
-      - name: Post Build | Sign the executable [macOS]
+      - name: Post Build | Sign the executables [macOS]
         if: matrix.os == 'macos-latest'
         env:
           LOCAL_KEYCHAIN_PASSWORD: ${{ secrets.LOCAL_KEYCHAIN_PASSWORD }}
@@ -114,12 +114,14 @@ jobs:
 
           # Sign `zinnia`
           codesign --timestamp --force --verbose \
+            --options runtime \
             --sign "$MACOS_SIGNING_IDENTITY" \
             --identifier "$MACOS_APP_ID" \
             target/${{ matrix.target }}/release/zinnia
 
           # Sign `zinniad`
           codesign --timestamp --force --verbose \
+            --options runtime \
             --sign "$MACOS_SIGNING_IDENTITY" \
             --identifier "$MACOS_APP_ID" \
             target/${{ matrix.target }}/release/zinniad
@@ -130,6 +132,19 @@ jobs:
           cd target/${{ matrix.target }}/release
           zip ../../../zinnia-${{ matrix.name }} zinnia
           zip ../../../zinniad-${{ matrix.name }} zinniad
+
+      - name: Post Build | Notarize the executables [macOS]
+        if: matrix.os == 'macos-latest'
+        run: |
+          xcrun notarytool submit zinnia-${{ matrix.name }} --wait \
+            --apple-id ${{ secrets.APPLE_ID }} \
+            --password ${{ secrets. APPLE_ID_PASSWORD }} \
+            --team-id ${{ secrets.APPLE_TEAM_ID }}
+
+          xcrun notarytool submit zinniad-${{ matrix.name }} --wait \
+            --apple-id ${{ secrets.APPLE_ID }} \
+            --password ${{ secrets. APPLE_ID_PASSWORD }} \
+            --team-id ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Release | Upload artifacts
         if: startsWith(github.ref, 'refs/tags/') # Don't create releases when debugging

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
- Bump the minimal required macOS version to 10.9 (see [Apple Notarization Requirements](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution))
- Notarize `zinnia` and `zinniad`

See #23