### PR TITLE
docs: install prebuilt binaries

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -32,11 +32,6 @@ If you have Rust tooling installed on your machine (see
 [Install Rust](https://www.rust-lang.org/tools/install)), you can build & install Zinnia from the
 source code.
 
-You also need the Protocol Buffers compiler, `protoc`. See
-[Protocol Buffer Compiler Installation](https://grpc.io/docs/protoc-installation/).
-
-Run the following command to build and install Zinnia:
-
 ```sh
 $ cargo install zinnia
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -16,21 +16,30 @@ executable.
 
 ## Installation
 
-To install Zinnia, you need to have Rust tooling installed on your machine. See
-[Install Rust](https://www.rust-lang.org/tools/install).
+You can download the `zinnia` binary from
+[our GitHub Releases](https://github.com/filecoin-station/zinnia/releases/latest).
+
+| OS      | Platform      | Filename                                                                                                               |
+| ------- | ------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Windows | Intel, 64bit  | [zinnia-windows-x64.zip](https://github.com/filecoin-station/zinnia/releases/latest/download/zinnia-windows-x64.zip)   |
+| macOS   | Intel, 64bit  | [zinnia-macos-x64.zip](https://github.com/filecoin-station/zinnia/releases/latest/download/zinnia-macos-x64.zip)       |
+| macOS   | Apple Silicon | [zinnia-macos-arm64.zip](https://github.com/filecoin-station/zinnia/releases/latest/download/zinnia-macos-arm64.zip)   |
+| Linux   | Intel, 64bit  | [zinnia-linux-x64.tar.gz](https://github.com/filecoin-station/zinnia/releases/latest/download/zinnia-linux-x64.tar.gz) |
+
+### Build from source
+
+If you have Rust tooling installed on your machine (see
+[Install Rust](https://www.rust-lang.org/tools/install)), you can build & install Zinnia from the
+source code.
 
 You also need the Protocol Buffers compiler, `protoc`. See
-[Protocol Buffer Compiler Installation](https://grpc.io/docs/protoc-installation/)
+[Protocol Buffer Compiler Installation](https://grpc.io/docs/protoc-installation/).
 
-Then you can install Zinnia using `cargo`:
+Run the following command to build and install Zinnia:
 
 ```sh
 $ cargo install zinnia
 ```
-
-This will build Zinnia and all its dependencies from source, which can take a while. In the future,
-we want to simplify the installation process, see
-[#23](https://github.com/filecoin-station/zinnia/issues/23).
 
 ## Basic use
 


### PR DESCRIPTION
Rework CLI Installation documentation to tell users where to download the release binaries of `zinnia` we are building for them.

We need to land #161 first.

See also #23

