### PR TITLE
feat: remove `protoc` dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,11 +29,6 @@ jobs:
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install Protoc
-        uses: arduino/setup-protoc@ab6203da1c3118e4406048171b09238ad31ad73e # latest
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@52e69531e6f69a396bc9d1226284493a5db969ff # v1
@@ -67,11 +62,6 @@ jobs:
           - target: "x86_64-unknown-linux-gnu"
             os: ubuntu-latest
     steps:
-      - name: Install Protoc
-        uses: arduino/setup-protoc@ab6203da1c3118e4406048171b09238ad31ad73e # latest
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@52e69531e6f69a396bc9d1226284493a5db969ff # v1
@@ -108,9 +98,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Install Protoc
-        run: sudo apt-get install protobuf-compiler
-
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@52e69531e6f69a396bc9d1226284493a5db969ff # v1
@@ -129,9 +116,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Install Protoc
-        run: sudo apt-get install protobuf-compiler
-
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@52e69531e6f69a396bc9d1226284493a5db969ff # v1
@@ -151,9 +135,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Install Protoc
-        run: sudo apt-get install protobuf-compiler
-
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@52e69531e6f69a396bc9d1226284493a5db969ff # v1


### PR DESCRIPTION
libp2p migrated from `prost` to `quick-protobuf`, this removed `protoc`
dependency. See https://github.com/libp2p/rust-libp2p/pull/3312
