### PR TITLE
fix!: rename zinniad env var to FIL_WALLET_ADDRESS

### DIFF
--- a/daemon/args.rs
+++ b/daemon/args.rs
@@ -6,7 +6,7 @@ use clap::{command, Parser, Subcommand};
 #[command(author, version, about, long_about = None)]
 pub struct CliArgs {
     /// Address of Station's built-in Filecoin wallet (required).
-    #[arg(long, short = 'w', env, name = "FIL ADDRESS")]
+    #[arg(long, short = 'w', env = "FIL_WALLET_ADDRESS", name = "FIL ADDRESS")]
     pub wallet_address: String,
 
     /// Directory where to keep state files.

--- a/daemon/args.rs
+++ b/daemon/args.rs
@@ -5,16 +5,16 @@ use clap::{command, Parser, Subcommand};
 #[derive(Parser, PartialEq, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct CliArgs {
-    /// Address of Station's built-in wallet (required).
-    #[arg(long, short = 'w', env)]
+    /// Address of Station's built-in Filecoin wallet (required).
+    #[arg(long, short = 'w', env, name = "FIL ADDRESS")]
     pub wallet_address: String,
 
     /// Directory where to keep state files.
-    #[arg(long, env, default_value_t = get_default_state_dir(env::var))]
+    #[arg(long, env, default_value_t = get_default_state_dir(env::var), name = "LOCAL STATE DIR PATH")]
     pub state_root: String,
 
     /// Directory where to keep temporary files like cached data.
-    #[arg(long, env, default_value_t = get_default_cache_dir(env::var))]
+    #[arg(long, env, default_value_t = get_default_cache_dir(env::var), name = "CACHE DIR PATH")]
     pub cache_root: String,
 
     /// List of modules to run, where each module is a single JS file. We don't make any assumptions


### PR DESCRIPTION
- docs: descriptive value names for zinniad args
- fix!: rename zinniad env var to FIL_WALLET_ADDRESS

New help output:

```
Zinnia daemon runs Zinnia modules inside Filecoin Station.

Usage: zinniad [OPTIONS] --wallet-address <FIL ADDRESS> [FILES]...

Arguments:
  [FILES]...  List of modules to run, where each module is a single JS file. We don't make any assumptions about the directory layout of modules. Paths are resolved relatively to the current working directory

Options:
  -w, --wallet-address <FIL ADDRESS>
          Address of Station's built-in Filecoin wallet (required) [env: FIL_WALLET_ADDRESS=]
      --state-root <LOCAL STATE DIR PATH>
          Directory where to keep state files [env: STATE_ROOT=] [default: "/Users/bajtos/Library/Application Support/app.filstation.zinniad"]
      --cache-root <CACHE DIR PATH>
          Directory where to keep temporary files like cached data [env: CACHE_ROOT=] [default: /Users/bajtos/Library/Caches/app.filstation.zinniad]
  -h, --help
          Print help
  -V, --version
          Print version
```