### PR TITLE
chore: disable Dependabot for Deno crates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,6 +12,12 @@ updates:
     reviewers:
       - "bajtos"
       - "juliangruber"
+    ignore:
+      # For Deno crates, ignore all semver-minor updates
+      # More often than not, these crates must be updated together,
+      # and Dependabot cannot do that yet (see https://github.com/github/roadmap/issues/148)
+      dependency-name: "deno_*"
+      update-types: ["version-update:semver-minor"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
More often than not, these crates must be updated together, and Dependabot cannot do that yet (see https://github.com/github/roadmap/issues/148)
