### PR TITLE
feat: persist job counter across restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
 
 [[package]]
+name = "atomicwrites"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1163d9d7c51de51a2b79d6df5e8888d11e9df17c752ce4a285fb6ca1580734e"
+dependencies = [
+ "rustix 0.37.7",
+ "tempfile",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1519,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,7 +2203,7 @@ checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.36.10",
  "windows-sys 0.45.0",
 ]
 
@@ -2705,6 +2727,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3165,7 +3193,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
@@ -3178,7 +3206,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -3631,6 +3659,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3833,10 +3870,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fe885c3a125aa45213b68cc1472a49880cb5923dc23f522ad2791b882228778"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+dependencies = [
+ "bitflags",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.6",
  "windows-sys 0.45.0",
 ]
 
@@ -4354,15 +4405,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.42.0",
+ "redox_syscall 0.3.5",
+ "rustix 0.37.7",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5693,12 +5744,14 @@ dependencies = [
 name = "zinniad"
 version = "0.7.0"
 dependencies = [
+ "atomicwrites",
  "clap",
  "env_logger",
  "log",
  "pretty_assertions",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "zinnia_runtime",
 ]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -14,6 +14,7 @@ path = "main.rs"
 doc = false
 
 [dependencies]
+atomicwrites = "0.4.1"
 clap = { version = "4.2.5", features = ["derive", "env"] }
 env_logger.workspace = true
 log.workspace = true
@@ -24,3 +25,4 @@ zinnia_runtime = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+tempfile = "3.5.0"

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -1,6 +1,8 @@
 mod args;
+mod state;
 mod station_reporter;
 
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -36,6 +38,9 @@ async fn run(config: CliArgs) -> Result<()> {
         ));
     }
 
+    let state_file = PathBuf::from(config.state_root).join("state.json");
+    log::debug!("Using state file: {}", state_file.display());
+
     log_info_activity("Module Runtime started.");
 
     let file = &config.files[0];
@@ -56,6 +61,7 @@ async fn run(config: CliArgs) -> Result<()> {
         ),
         wallet_address: config.wallet_address,
         reporter: Rc::new(StationReporter::new(
+            state_file,
             Duration::from_millis(200),
             module_name.into(),
         )),

--- a/daemon/state.rs
+++ b/daemon/state.rs
@@ -1,0 +1,99 @@
+use atomicwrites::{AtomicFile, OverwriteBehavior};
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::Path;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct State {
+    pub total_jobs_completed: u64,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            total_jobs_completed: 0,
+        }
+    }
+}
+
+pub fn load(state_file: &Path) -> State {
+    log::debug!("Loading initial state from {}", state_file.display());
+    match std::fs::read_to_string(state_file) {
+        Err(err) => {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                log::warn!(
+                    "Cannot read initial state from {}: {}",
+                    state_file.display(),
+                    err
+                );
+            }
+            return State::default();
+        }
+        Ok(data) => match serde_json::from_str::<State>(&data) {
+            Err(err) => {
+                log::warn!(
+                    "Cannot parse initial state from {}: {}",
+                    state_file.display(),
+                    err
+                );
+                return State::default();
+            }
+            Ok(state) => {
+                log::debug!("Initial state: {:?}", state);
+                return state;
+            }
+        },
+    }
+}
+
+pub fn store(state_file: &Path, state: &State) {
+    if let Some(parent) = state_file.parent() {
+        if let Err(err) = std::fs::create_dir_all(&parent) {
+            log::warn!(
+                "Cannot create state directory {}: {}",
+                parent.display(),
+                err
+            );
+            return;
+        }
+    }
+
+    let payload = match serde_json::to_string_pretty(&state) {
+        Err(err) => {
+            log::warn!("Cannot serialize state: {}", err);
+            return;
+        }
+
+        Ok(payload) => payload,
+    };
+
+    let write_result = AtomicFile::new(state_file, OverwriteBehavior::AllowOverwrite)
+        .write(|f| f.write_all(payload.as_bytes()));
+    match write_result {
+        Err(err) => log::warn!("Cannot write state to {}: {}", state_file.display(), err),
+        Ok(()) => log::debug!("State stored in {}", state_file.display()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use tempfile;
+    use zinnia_runtime::anyhow::Result;
+
+    #[test]
+    fn creates_missing_directories() -> Result<()> {
+        let state_dir = tempfile::tempdir()?;
+        let state_file = state_dir.path().join("subdir").join("state.json");
+        store(
+            &state_file,
+            &State {
+                total_jobs_completed: 1,
+            },
+        );
+        let loaded = load(&state_file);
+        assert_eq!(loaded.total_jobs_completed, 1);
+        Ok(())
+    }
+}

--- a/daemon/state.rs
+++ b/daemon/state.rs
@@ -27,7 +27,7 @@ pub fn load(state_file: &Path) -> State {
                     err
                 );
             }
-            return State::default();
+            State::default()
         }
         Ok(data) => match serde_json::from_str::<State>(&data) {
             Err(err) => {
@@ -36,11 +36,11 @@ pub fn load(state_file: &Path) -> State {
                     state_file.display(),
                     err
                 );
-                return State::default();
+                State::default()
             }
             Ok(state) => {
                 log::debug!("Initial state: {:?}", state);
-                return state;
+                state
             }
         },
     }

--- a/daemon/state.rs
+++ b/daemon/state.rs
@@ -16,62 +16,65 @@ impl Default for State {
     }
 }
 
-pub fn load(state_file: &Path) -> State {
-    log::debug!("Loading initial state from {}", state_file.display());
-    match std::fs::read_to_string(state_file) {
-        Err(err) => {
-            if err.kind() != std::io::ErrorKind::NotFound {
-                log::warn!(
-                    "Cannot read initial state from {}: {}",
-                    state_file.display(),
-                    err
-                );
-            }
-            State::default()
-        }
-        Ok(data) => match serde_json::from_str::<State>(&data) {
+impl State {
+    pub fn load(state_file: &Path) -> Self {
+        log::debug!("Loading initial state from {}", state_file.display());
+        match std::fs::read_to_string(state_file) {
             Err(err) => {
-                log::warn!(
-                    "Cannot parse initial state from {}: {}",
-                    state_file.display(),
-                    err
-                );
+                if err.kind() != std::io::ErrorKind::NotFound {
+                    log::warn!(
+                        "Cannot read initial state from {}: {}",
+                        state_file.display(),
+                        err
+                    );
+                }
                 State::default()
             }
-            Ok(state) => {
-                log::debug!("Initial state: {:?}", state);
-                state
+            Ok(data) => match serde_json::from_str::<State>(&data) {
+                Err(err) => {
+                    log::warn!(
+                        "Cannot parse initial state from {}: {}",
+                        state_file.display(),
+                        err
+                    );
+                    State::default()
+                }
+                Ok(state) => {
+                    log::debug!("Initial state: {:?}", state);
+                    state
+                }
+            },
+        }
+    }
+
+    pub fn store(&self, state_file: &Path) {
+        if let Some(parent) = state_file.parent() {
+            if let Err(err) = std::fs::create_dir_all(&parent) {
+                log::warn!(
+                    "Cannot create state directory {}: {}",
+                    parent.display(),
+                    err
+                );
+                return;
             }
-        },
-    }
-}
-
-pub fn store(state_file: &Path, state: &State) {
-    if let Some(parent) = state_file.parent() {
-        if let Err(err) = std::fs::create_dir_all(&parent) {
-            log::warn!(
-                "Cannot create state directory {}: {}",
-                parent.display(),
-                err
-            );
-            return;
-        }
-    }
-
-    let payload = match serde_json::to_string_pretty(&state) {
-        Err(err) => {
-            log::warn!("Cannot serialize state: {}", err);
-            return;
         }
 
-        Ok(payload) => payload,
-    };
+        let payload = match serde_json::to_string_pretty(self) {
+            Err(err) => {
+                log::warn!("Cannot serialize state: {}", err);
+                return;
+            }
 
-    let write_result = AtomicFile::new(state_file, OverwriteBehavior::AllowOverwrite)
-        .write(|f| f.write_all(payload.as_bytes()));
-    match write_result {
-        Err(err) => log::warn!("Cannot write state to {}: {}", state_file.display(), err),
-        Ok(()) => log::debug!("State stored in {}", state_file.display()),
+            Ok(payload) => payload,
+        };
+
+        let write_result = AtomicFile::new(state_file, OverwriteBehavior::AllowOverwrite)
+            .write(|f| f.write_all(payload.as_bytes()));
+
+        match write_result {
+            Err(err) => log::warn!("Cannot write state to {}: {}", state_file.display(), err),
+            Ok(()) => log::debug!("State stored in {}", state_file.display()),
+        }
     }
 }
 
@@ -86,13 +89,11 @@ mod tests {
     fn creates_missing_directories() -> Result<()> {
         let state_dir = tempfile::tempdir()?;
         let state_file = state_dir.path().join("subdir").join("state.json");
-        store(
-            &state_file,
-            &State {
-                total_jobs_completed: 1,
-            },
-        );
-        let loaded = load(&state_file);
+        let state = State {
+            total_jobs_completed: 1,
+        };
+        state.store(&state_file);
+        let loaded = State::load(&state_file);
         assert_eq!(loaded.total_jobs_completed, 1);
         Ok(())
     }

--- a/daemon/state.rs
+++ b/daemon/state.rs
@@ -54,7 +54,6 @@ impl State {
 
         write_result.with_context(|| format!("Cannot write state to {}", state_file.display()))?;
         log::debug!("State stored in {}", state_file.display());
-
         Ok(())
     }
 }

--- a/daemon/station_reporter.rs
+++ b/daemon/station_reporter.rs
@@ -154,7 +154,6 @@ mod tests {
         assert_eq!(reporter.tracker.borrow().counter(), 0, "initial count");
 
         reporter.job_completed();
-        println!("{:?}", reporter.tracker);
         assert_eq!(
             reporter.tracker.borrow().counter(),
             1,
@@ -162,7 +161,6 @@ mod tests {
         );
 
         let reporter = StationReporter::new(state_file, NO_DELAY, "test".into());
-        println!("{:?}", reporter.tracker);
         assert_eq!(
             reporter.tracker.borrow().counter(),
             1,

--- a/daemon/station_reporter.rs
+++ b/daemon/station_reporter.rs
@@ -49,15 +49,17 @@ impl StationReporter {
             "modules": modules,
         });
 
-        let _ = print_event(&event);
-        // ^^^ We are ignoring errors because there isn't much to do in such case
+        print_event(&event);
     }
 }
 
-fn print_event(data: &serde_json::Value) -> Result<()> {
-    writeln!(stdout(), "{data}")?;
-    stdout().flush()?;
-    Ok(())
+fn print_event(data: &serde_json::Value) {
+    writeln!(stdout(), "{data}")
+        .and_then(|_| stdout().flush())
+        .unwrap_or_else(|err| {
+            // We are ignoring errors because there isn't much to do in such case
+            log::debug!("Cannot print event {}: {}", data, err);
+        });
 }
 
 pub fn log_info_activity(msg: &str) {
@@ -66,8 +68,7 @@ pub fn log_info_activity(msg: &str) {
         "module": serde_json::Value::Null,
         "message": msg,
     });
-    let _ = print_event(&event);
-    // ^^^ We are ignoring errors because there isn't much to do in such case
+    print_event(&event);
 }
 
 #[allow(unused)]
@@ -77,8 +78,7 @@ pub fn log_error_activity(msg: &str) {
         "module": serde_json::Value::Null,
         "message": msg,
     });
-    let _ = print_event(&event);
-    // ^^^ We are ignoring errors because there isn't much to do in such case
+    print_event(&event);
 }
 
 impl Drop for StationReporter {
@@ -105,8 +105,7 @@ impl Reporter for StationReporter {
             "module": self.module_name,
             "message": msg,
         });
-        let _ = print_event(&event);
-        // ^^^ We are ignoring errors because there isn't much to do in such case
+        print_event(&event);
     }
 
     fn error_activity(&self, msg: &str) {
@@ -115,8 +114,7 @@ impl Reporter for StationReporter {
             "module": self.module_name,
             "message": msg,
         });
-        let _ = print_event(&event);
-        // ^^^ We are ignoring errors because there isn't much to do in such case
+        print_event(&event);
     }
 
     fn job_completed(&self) {

--- a/daemon/station_reporter.rs
+++ b/daemon/station_reporter.rs
@@ -4,10 +4,9 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use serde_json::{json, Map};
-use zinnia_runtime::anyhow::Result;
 use zinnia_runtime::{JobCompletionTracker, LogLevel, Reporter};
 
-use crate::state::{self, State};
+use crate::state::State;
 
 /// StationReporter reports activities to stdout as ND-JSON stream and all Console logs to stderr
 pub struct StationReporter {
@@ -23,7 +22,7 @@ impl StationReporter {
     /// `job_report_delay` specifies how often the information about new jobs is printed.
     pub fn new(state_file: PathBuf, job_report_delay: Duration, module_name: String) -> Self {
         let log_target = format!("module:{module_name}");
-        let initial_job_count = state::load(&state_file).total_jobs_completed;
+        let initial_job_count = State::load(&state_file).total_jobs_completed;
 
         Self {
             tracker: RefCell::new(JobCompletionTracker::new(
@@ -126,7 +125,7 @@ impl Reporter for StationReporter {
         let state = State {
             total_jobs_completed,
         };
-        state::store(&self.state_file, &state);
+        state.store(&self.state_file);
     }
 }
 
@@ -135,6 +134,7 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
     use tempfile;
+    use zinnia_runtime::anyhow::Result;
 
     const NO_DELAY: Duration = Duration::from_millis(0);
 


### PR DESCRIPTION
- zinniad: persist "jobs completed" across restarts
- refactor: code cleanup in reporters

Resolves #148

The implementation is a bit hacky. We will need to refactor it to enable support for more than one module (see #144). Right now, I am optimising to deliver Zinnia in Station ASAP.

It's probably best to review the changes commit by commit.