### PR TITLE
fix: use older glibc for linux-x64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             name: linux-x64.tar.gz
+            # Build using `cross` to link against an older `glibc` version that's compatible
+            # with more Linux distros. When building on `ubuntu-latest`, we link against the
+            # latest glibc version, and `zinniad` cannot start e.g. in `node:18` Docker image
+            # based on Debian Bullseye distro.
+            builder: cross
 
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest


### PR DESCRIPTION
Before this change, the release builds of `zinniad` were crashing on certain Linux distros (Debian Bullseye in `node:18` Docker image) providing an older glibc version.

I discovered this problem while working on https://github.com/filecoin-station/core/pull/92, where the Docker tests failed.

https://github.com/filecoin-station/core/actions/runs/4863716712/jobs/8671800364?pr=92#step:9:9
```
[5/2/2023, 4:56:19 PM] ERROR Cannot start Zinnia Runtime: Command failed with exit code 1: /usr/src/app/modules/runtime/zinniad peer-checker/peer-checker.js
[5/2/2023, 4:56:19 PM] /usr/src/app/modules/runtime/zinniad: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /usr/src/app/modules/runtime/zinniad)
[5/2/2023, 4:56:19 PM] /usr/src/app/modules/runtime/zinniad: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /usr/src/app/modules/runtime/zinniad)
[5/2/2023, 4:56:19 PM] /usr/src/app/modules/runtime/zinniad: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/src/app/modules/runtime/zinniad)
```

I was able to reproduce the problem locally too.

```sh
$ docker build --platform linux/amd64 . --no-cache --progress=plain
[...]
[writing image sha256:(image-sha)]

$ docker run --rm \
  --name station \
  --env FIL_WALLET_ADDRESS=f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za \
  <image-sha from the build>
[...]
[5/3/2023, 7:26:12 AM] ERROR Cannot start Zinnia Runtime: Command failed with exit code 1: /usr/src/app/modules/runtime/zinniad peer-checker/peer-checker.js
[5/3/2023, 7:26:12 AM] /usr/src/app/modules/runtime/zinniad: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /usr/src/app/modules/runtime/zinniad)
[5/3/2023, 7:26:12 AM] /usr/src/app/modules/runtime/zinniad: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /usr/src/app/modules/runtime/zinniad)
[5/3/2023, 7:26:12 AM] /usr/src/app/modules/runtime/zinniad: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/src/app/modules/runtime/zinniad)
```

Weirdly enough, the problem was specific to `linux/amd64`. When I built and ran the image for `linux/arm64` (my native arch), Zinnia started without issues.

Then I investigated what glibc version the `cross` builder uses (see [Supported targets](https://github.com/cross-rs/cross#supported-targets)) and found that it's using glibc version 2.31. That's presumably an older version than the one shipped in the latest Ubuntu. This explains why `zinniad` for `arm64` built using `cross` works but `zinniad` for `x64` built using native tooling on ubuntu-latest does not work.


