### PR TITLE
feat: embed Deno assertions as `zinnia:assert`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,7 +3,7 @@
 !**/*.md
 !**/*.js
 runtime/vendored
-runtime/tests/js/vendored
+runtime/js/vendored
 target
 
 # Let's keep LICENSE.md in the same formatting as we use in other PL repositories

--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -321,3 +321,18 @@ Tracking issue: n/a
 #### Other
 
 - `XMLHttpRequest` Standard
+
+## Assertions
+
+Zinnia bundles assertion functions provided by Deno's `std/testing/asserts.ts`.
+
+Example:
+
+```js
+import { assertEquals } from "zinnia:assert";
+assertEquals(true, false);
+// ^ throws an error
+```
+
+You can find the API documentation at deno.land website:
+[https://deno.land/std@0.183.0/testing/asserts.ts](https://deno.land/std@0.183.0/testing/asserts.ts)

--- a/runtime/ext.rs
+++ b/runtime/ext.rs
@@ -50,6 +50,7 @@ deno_core::extension!(
       "98_global_scope.js",
       "internals.js",
       "test.js",
+      "vendored/asserts.bundle.js",
       "99_main.js",
     ],
     options = {

--- a/runtime/js/vendored/asserts.bundle.js
+++ b/runtime/js/vendored/asserts.bundle.js
@@ -2,8 +2,6 @@
 // deno-lint-ignore-file
 // This code was bundled using `deno bundle` and it's not recommended to edit it manually
 
-// const { Deno  } = globalThis;
-// const noColor = typeof Deno?.noColor === "boolean" ? Deno.noColor : true;
 const noColor = false;
 let enabled = !noColor;
 function code(open, close) {

--- a/runtime/module_loader.rs
+++ b/runtime/module_loader.rs
@@ -52,7 +52,12 @@ impl ModuleLoader for ZinniaModuleLoader {
     ) -> Result<ModuleSpecifier, AnyError> {
         if specifier == "zinnia:test" {
             return Ok(ModuleSpecifier::parse("ext:zinnia_runtime/test.js").unwrap());
+        } else if specifier == "zinnia:assert" {
+            return Ok(
+                ModuleSpecifier::parse("ext:zinnia_runtime/vendored/asserts.bundle.js").unwrap(),
+            );
         }
+
         let resolved = resolve_import(specifier, referrer)?;
         Ok(resolved)
     }

--- a/runtime/tests/js/fetch_tests.js
+++ b/runtime/tests/js/fetch_tests.js
@@ -1,5 +1,5 @@
 import { test } from "zinnia:test";
-import { assert, assertEquals } from "./vendored/asserts.bundle.js";
+import { assert, assertEquals } from "zinnia:assert";
 
 test("fetch", async () => {
   const res = await fetch("https://google.com/");

--- a/runtime/tests/js/libp2p_tests.js
+++ b/runtime/tests/js/libp2p_tests.js
@@ -1,5 +1,5 @@
-import { assert, assertEquals } from "./vendored/asserts.bundle.js";
 import { test } from "zinnia:test";
+import { assert, assertEquals } from "zinnia:assert";
 
 test("get peer id", () => {
   const id = Zinnia.peerId;

--- a/runtime/tests/js/module_loader_tests.js
+++ b/runtime/tests/js/module_loader_tests.js
@@ -1,5 +1,5 @@
-import { assertEquals, assertMatch, assertRejects } from "./vendored/asserts.bundle.js";
 import { test } from "zinnia:test";
+import { assertEquals, assertMatch, assertRejects } from "zinnia:assert";
 
 test("dynamically import file next to the main module file", async () => {
   const { KEY } = await import("./empty_module.js");

--- a/runtime/tests/js/station_apis_tests.js
+++ b/runtime/tests/js/station_apis_tests.js
@@ -1,5 +1,5 @@
-import { assertStrictEquals } from "./vendored/asserts.bundle.js";
 import { test } from "zinnia:test";
+import { assertStrictEquals } from "zinnia:assert";
 
 test("Zinnia.walletAddress", () => {
   // Runtime JS tests are executed with the default configuration

--- a/runtime/tests/js/webapis_tests.js
+++ b/runtime/tests/js/webapis_tests.js
@@ -1,5 +1,5 @@
-import { assertEquals } from "./vendored/asserts.bundle.js";
 import { test } from "zinnia:test";
+import { assertEquals } from "zinnia:assert";
 
 test("AbortController", () => {
   assertEquals(typeof AbortController, "function", "typeof AbortController");

--- a/runtime/tests/js/webcrypto_tests.js
+++ b/runtime/tests/js/webcrypto_tests.js
@@ -1,5 +1,5 @@
-import { assertEquals, assertNotEquals } from "./vendored/asserts.bundle.js";
 import { test } from "zinnia:test";
+import { assertEquals, assertNotEquals } from "zinnia:assert";
 
 test("getRandomValues()", async () => {
   const first = new Uint8Array(4);


### PR DESCRIPTION
Example usage:

```js
import { test } from "zinnia:test";
import { assertEquals } from "zinnia:assert";

test("AbortController", () => {
  assertEquals(typeof AbortController, "function", "typeof AbortController");
  assertEquals(AbortController.name, "AbortController", "AbortController.name");
});
```

See #44
