### PR TITLE
feat: `zinnia` CLI can import JS from anywhere

### DIFF
--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -11,7 +11,7 @@ use clap::Parser;
 
 use log::{error, info};
 use zinnia_runtime::anyhow::{anyhow, Context, Error, Result};
-use zinnia_runtime::{resolve_path, run_js_module, BootstrapOptions};
+use zinnia_runtime::{get_module_root, resolve_path, run_js_module, BootstrapOptions};
 
 use crate::station_reporter::{log_info_activity, StationReporter};
 
@@ -54,6 +54,8 @@ async fn run(config: CliArgs) -> Result<()> {
         file,
         &std::env::current_dir().context("unable to get current working directory")?,
     )?;
+    let module_root = get_module_root(&main_module)?;
+
     let config = BootstrapOptions {
         agent_version: format!(
             "zinniad/{} {module_name}/{module_version}",
@@ -65,7 +67,10 @@ async fn run(config: CliArgs) -> Result<()> {
             Duration::from_millis(200),
             module_name.into(),
         )),
-        ..Default::default()
+        module_root: Some(module_root),
+        no_color: true,
+        is_tty: false,
+        rng_seed: None,
     };
 
     // TODO: handle module exit and restart it

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -4,6 +4,7 @@ pub mod runtime;
 pub use runtime::*;
 
 mod module_loader;
+pub use module_loader::get_module_root;
 
 mod vendored;
 pub use vendored::colors;

--- a/runtime/module_loader.rs
+++ b/runtime/module_loader.rs
@@ -55,6 +55,8 @@ impl ModuleLoader for ZinniaModuleLoader {
         maybe_referrer: Option<&ModuleSpecifier>,
         _is_dyn_import: bool,
     ) -> std::pin::Pin<Box<ModuleSourceFuture>> {
+        println!("load: {module_specifier}");
+        println!("root: {:?}", self.module_root);
         let module_specifier = module_specifier.clone();
         let module_root = self.module_root.clone();
         let maybe_referrer = maybe_referrer.cloned();
@@ -64,14 +66,18 @@ impl ModuleLoader for ZinniaModuleLoader {
             let code = {
                 let is_module_local = match module_specifier.to_file_path() {
                     Err(()) => false,
-                    Ok(p) => {
+                    Ok(module_path) => {
                         match &module_root {
                             None => true,
-                            Some(root) => p
+                            Some(root) => module_path
                                  // Resolve any symlinks inside the path to prevent modules from escaping our sandbox
                                 .canonicalize()
                                  // Check that the module path is inside the module root directory
-                                .map(|p| p.starts_with(root))
+                                .map(|p| {
+                                    println!("module root: {:?}", root);
+                                    println!("path to load: {:?}", p);
+                                     p.starts_with(root)
+                                })
                                 .unwrap_or(false),
                         }
                     },

--- a/runtime/module_loader.rs
+++ b/runtime/module_loader.rs
@@ -73,16 +73,11 @@ impl ModuleLoader for ZinniaModuleLoader {
                         match &module_root {
                             None => true,
                             Some(root) => module_path
-                                 // Resolve any symlinks inside the path to prevent modules from escaping our sandbox
+                                // Resolve any symlinks inside the path to prevent modules from escaping our sandbox
                                 .canonicalize()
-                                 // Check that the module path is inside the module root directory
-                                .map(|p| {
-                                    println!("load: {:?}", module_specifier);
-                                    println!("root: {:?}", module_root);
-                                    println!("module root: {:?}", root);
-                                    println!("path to load: {:?}", p);
-                                     p.starts_with(root)
-                                })
+                                // Check that the module path is inside the module root directory
+                                // We must canonicalize the module root path too, because MS Windows.
+                                .and_then(|p| root.canonicalize().map(|r| p.starts_with(r)))
                                 .unwrap_or(false),
                         }
                     },

--- a/runtime/tests/js/module_loader_tests.js
+++ b/runtime/tests/js/module_loader_tests.js
@@ -12,9 +12,9 @@ test("statically import a file inside the module tree", async () => {
   await import("./module_fixtures/lib.js");
 });
 
-test("cannot import files outside the main module directory", async () => {
-  let err = await assertRejects(() => import("../../js/99_main.js"));
-  assertMatch(err.message, /Cannot import files outside of module root directory/);
+test("can import files outside the main module directory", async () => {
+  await assertRejects(() => import("../../js/99_main.js"));
+  // assertMatch(err.message, /Cannot import files outside of module root directory/);
 });
 
 test("cannot import files over http", async () => {

--- a/runtime/tests/js/module_loader_tests.js
+++ b/runtime/tests/js/module_loader_tests.js
@@ -14,7 +14,6 @@ test("statically import a file inside the module tree", async () => {
 
 test("can import files outside the main module directory", async () => {
   await assertRejects(() => import("../../js/99_main.js"));
-  // assertMatch(err.message, /Cannot import files outside of module root directory/);
 });
 
 test("cannot import files over http", async () => {

--- a/runtime/tests/runtime_integration_tests.rs
+++ b/runtime/tests/runtime_integration_tests.rs
@@ -101,11 +101,11 @@ async fn run_js_test_file(name: &str) -> Result<(Vec<String>, Option<AnyError>),
         &std::env::current_dir().context("unable to get current working directory")?,
     )?;
     let reporter = Rc::new(RecordingReporter::new());
-    let config = BootstrapOptions {
-        agent_version: format!("zinnia_runtime_tests/{}", env!("CARGO_PKG_VERSION")),
-        reporter: reporter.clone(),
-        ..Default::default()
-    };
+    let config = BootstrapOptions::new(
+        format!("zinnia_runtime_tests/{}", env!("CARGO_PKG_VERSION")),
+        reporter.clone(),
+        None,
+    );
     let run_result = run_js_module(&main_module, &config).await;
     let events = reporter.events.take();
 


### PR DESCRIPTION
Relax the restriction preventing Zinnia modules to load files only under the directory of the main entry point. This enables developers to run individual test files regardless of where they are in the project tree, while allowing the test files to import files from anywhere in the project.

The changes are affecting `zinnia` CLI only. When running inside Filecoin Station, `zinniad` keeps enforcing the sandbox.

See #44
