### PR TITLE
feat: prettify test failures

### DIFF
--- a/runtime/ext.rs
+++ b/runtime/ext.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::rc::Rc;
 
 use deno_core::anyhow::Result;
+use deno_core::error::JsError;
 use deno_core::url::Url;
 use deno_core::{op, OpState};
 use deno_fetch::FetchPermissions;
@@ -42,6 +43,7 @@ deno_core::extension!(
         op_info_activity,
         op_error_activity,
         op_zinnia_log,
+        op_format_test_error
     ],
     esm = [
       dir "js",
@@ -86,4 +88,9 @@ fn op_error_activity(state: &mut OpState, msg: &str) {
 fn op_zinnia_log(state: &mut OpState, msg: &str, level: LogLevel) {
     let reporter = state.borrow::<StoredReporter>();
     reporter.log(level, msg);
+}
+
+#[op]
+fn op_format_test_error(error: JsError) -> String {
+    crate::vendored::cli_tools::format_test_error(&error)
 }

--- a/runtime/js/internals.js
+++ b/runtime/js/internals.js
@@ -3,3 +3,9 @@
 // even after our bootstrapper deleted the global `Deno` object
 
 export const DenoCore = globalThis.Deno.core;
+
+export function format_test_error(error) {
+  return typeof error === "object" && error instanceof Error
+    ? DenoCore.ops.op_format_test_error(DenoCore.destructureError(error))
+    : error;
+}

--- a/runtime/js/test.js
+++ b/runtime/js/test.js
@@ -1,7 +1,7 @@
 // A minimalistic test framework for testing Zinnia modules
 // Inspired by `node:test`, `Deno.test`, `mocha` and others
 
-import { DenoCore } from "ext:zinnia_runtime/internals.js";
+import { DenoCore, format_test_error } from "ext:zinnia_runtime/internals.js";
 
 /** @type {{
    pendingTests: TestCase[];
@@ -122,7 +122,8 @@ class TestFailure {
   render() {
     let location = grey(`=> ${displayTestLocation(this.testCase.location)}`);
     return `${this.testCase.name} ${location}\n${boldRed("error:")} ${
-      this.error.stack || this.error
+      format_test_error(this.error)
+      // this.error.stack || this.error
     }`;
   }
 }

--- a/runtime/js/test.js
+++ b/runtime/js/test.js
@@ -121,10 +121,8 @@ class TestFailure {
 
   render() {
     let location = grey(`=> ${displayTestLocation(this.testCase.location)}`);
-    return `${this.testCase.name} ${location}\n${boldRed("error:")} ${
-      format_test_error(this.error)
-      // this.error.stack || this.error
-    }`;
+    let reason = format_test_error(this.error);
+    return `${this.testCase.name} ${location}\n${boldRed("error:")} ${reason}`;
   }
 }
 

--- a/runtime/tests/js/test_runner_tests/failing_tests.activity.txt
+++ b/runtime/tests/js/test_runner_tests/failing_tests.activity.txt
@@ -7,8 +7,8 @@ failing_tests.js
 
 failing test => file:///project-root/tests/js/test_runner_tests/failing_tests.js:7:1
 error: Error: this failed
+  throw new Error("this failed");
+        ^
     at TestCase.fn (file:///project-root/tests/js/test_runner_tests/failing_tests.js:8:9)
-    at TestCase.execute (ext:zinnia_runtime/test.js:57:27)
-    at runNextTest (ext:zinnia_runtime/test.js:134:14)
 
 FAIL | 1 passed | 1 failed (XXms)

--- a/runtime/vendored.rs
+++ b/runtime/vendored.rs
@@ -1,2 +1,3 @@
+pub mod cli_tools;
 pub mod colors;
 pub mod fmt_errors;

--- a/runtime/vendored/cli_tools.rs
+++ b/runtime/vendored/cli_tools.rs
@@ -1,0 +1,64 @@
+// https://github.com/denoland/deno/blob/v1.33.3/cli/tools/test.rs
+//
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+use crate::fmt_errors::format_js_error;
+use deno_core::error::JsError;
+
+fn abbreviate_test_error(js_error: &JsError) -> JsError {
+    let mut js_error = js_error.clone();
+    let frames = std::mem::take(&mut js_error.frames);
+
+    // check if there are any stack frames coming from user code
+    let should_filter = frames.iter().any(|f| {
+        if let Some(file_name) = &f.file_name {
+            !(file_name.starts_with("[ext:") || file_name.starts_with("ext:"))
+        } else {
+            true
+        }
+    });
+
+    if should_filter {
+        let mut frames = frames
+            .into_iter()
+            .rev()
+            .skip_while(|f| {
+                if let Some(file_name) = &f.file_name {
+                    file_name.starts_with("[ext:") || file_name.starts_with("ext:")
+                } else {
+                    false
+                }
+            })
+            .collect::<Vec<_>>();
+        frames.reverse();
+        js_error.frames = frames;
+    } else {
+        js_error.frames = frames;
+    }
+
+    js_error.cause = js_error
+        .cause
+        .as_ref()
+        .map(|e| Box::new(abbreviate_test_error(e)));
+    js_error.aggregated = js_error
+        .aggregated
+        .as_ref()
+        .map(|es| es.iter().map(abbreviate_test_error).collect());
+    js_error
+}
+
+// This function prettifies `JsError` and applies some changes specifically for
+// test runner purposes:
+//
+// - filter out stack frames:
+//   - if stack trace consists of mixed user and internal code, the frames
+//     below the first user code frame are filtered out
+//   - if stack trace consists only of internal code it is preserved as is
+pub fn format_test_error(js_error: &JsError) -> String {
+    let mut js_error = abbreviate_test_error(js_error);
+    js_error.exception_message = js_error
+        .exception_message
+        .trim_start_matches("Uncaught ")
+        .to_string();
+    format_js_error(&js_error)
+}


### PR DESCRIPTION
Vendor `format_test_error()` from Deno CLI and use it to format test failures.

Output before my changes - notice the stack frames pointing to Zinnia internals (`ext:zinnia_runtime`)

<img width="1047" alt="Screenshot 2023-05-18 at 12 57 08" src="https://github.com/filecoin-station/zinnia/assets/1140553/a5161976-4a8c-4567-958b-18129cf2ce36">

New output:

<img width="1044" alt="Screenshot 2023-05-18 at 12 55 37" src="https://github.com/filecoin-station/zinnia/assets/1140553/7e5d3bed-2aa3-48c7-86eb-3e8cf2da6939">

Output of `deno test` for comparison:

<img width="918" alt="Screenshot 2023-05-18 at 13 00 24" src="https://github.com/filecoin-station/zinnia/assets/1140553/649c5cf1-bd50-48c1-878d-cd0e84fdc4a8">


See #44 