### PR TITLE
fix: user agent reported by Fetch client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5751,6 +5751,7 @@ dependencies = [
 name = "zinnia_runtime"
 version = "0.9.0"
 dependencies = [
+ "assert_fs",
  "atty",
  "chrono",
  "console_static_text",

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -48,7 +48,6 @@ async fn run(config: CliArgs) -> Result<()> {
     // TODO: configurable module name and version
     // https://github.com/filecoin-station/zinnia/issues/147
     let module_name = file.trim_end_matches(".js");
-    let module_version = "unknown";
 
     let main_module = resolve_path(
         file,
@@ -57,10 +56,7 @@ async fn run(config: CliArgs) -> Result<()> {
     let module_root = get_module_root(&main_module)?;
 
     let config = BootstrapOptions {
-        agent_version: format!(
-            "zinniad/{} {module_name}/{module_version}",
-            env!("CARGO_PKG_VERSION")
-        ),
+        agent_version: format!("zinniad/{} {module_name}", env!("CARGO_PKG_VERSION")),
         wallet_address: config.wallet_address,
         reporter: Rc::new(StationReporter::new(
             state_file,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { workspace = true, features = ["fs"] }
 zinnia_libp2p.workspace = true
 
 [dev-dependencies]
+assert_fs = { workspace = true }
 console_static_text = "0.8.1"
 env_logger.workspace = true
 pretty_assertions = { workspace = true }

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -84,7 +84,10 @@ pub async fn run_js_module(
                 blob_store,
                 Some(module_specifier.clone()),
             ),
-            deno_fetch::deno_fetch::init_ops_and_esm::<ZinniaPermissions>(Default::default()),
+            deno_fetch::deno_fetch::init_ops_and_esm::<ZinniaPermissions>(deno_fetch::Options {
+                user_agent: bootstrap_options.agent_version.clone(),
+                ..Default::default()
+            }),
             deno_crypto::deno_crypto::init_ops_and_esm(bootstrap_options.rng_seed),
             // Zinnia-specific APIs
             zinnia_libp2p::zinnia_libp2p::init_ops_and_esm(zinnia_libp2p::PeerNodeConfig {

--- a/runtime/tests/fetch_api_tests.rs
+++ b/runtime/tests/fetch_api_tests.rs
@@ -1,0 +1,108 @@
+// Integration tests making Fetch API request against a custom HTTP server
+
+use std::rc::Rc;
+
+use anyhow::{Context, Result};
+use assert_fs::prelude::*;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use zinnia_runtime::{anyhow, deno_core, run_js_module, BootstrapOptions, RecordingReporter};
+
+#[tokio::test]
+async fn fetch_reports_user_agent() -> Result<()> {
+    let user_agent = "zinnia_fetch_api_tests agent/007";
+    let server_port = start_echo_server().await?;
+
+    let mod_js = assert_fs::NamedTempFile::new("fetch-test.js")?;
+    mod_js.write_str(&format!(
+        r#"
+import {{ assertArrayIncludes }} from "zinnia:assert";
+const response = await (await fetch("http://127.0.0.1:{server_port}/echo")).text();
+console.log("RESPONSE\n%s", response);
+const request_lines = response.split(/\r\n/g);
+assertArrayIncludes(request_lines, ["user-agent: {user_agent}"]);
+"#,
+    ))?;
+
+    let main_module = deno_core::resolve_path(
+        &mod_js.to_string_lossy(),
+        &std::env::current_dir().context("unable to get current working directory")?,
+    )?;
+    let reporter = Rc::new(RecordingReporter::new());
+    let config = BootstrapOptions::new(user_agent.into(), reporter.clone(), None);
+    run_js_module(&main_module, &config).await?;
+    // the test passes when the JavaScript code does not throw
+    Ok(())
+}
+
+// TODO: return something that will allow the caller to stop the server
+async fn start_echo_server() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("cannot listen on localhost")?;
+    let port = listener.local_addr()?.port();
+    tokio::spawn(echo_server(listener));
+    Ok(port)
+}
+
+async fn echo_server(listener: TcpListener) {
+    println!("[server] Listening on: {:?}", listener.local_addr());
+    loop {
+        let (mut socket, _) = listener
+            .accept()
+            .await
+            .expect("cannot accept incoming connection");
+        println!("[server] connection accepted");
+
+        tokio::spawn(async move {
+            let mut header_sent = false;
+            let mut buf = vec![0; 1024];
+            loop {
+                let n = socket
+                    .read(&mut buf)
+                    .await
+                    .expect("failed to read data from socket");
+                println!("[server] Read {n} bytes");
+
+                if !header_sent {
+                    header_sent = true;
+                    socket
+                        .write_all(
+                            vec![
+                                "HTTP/1.1 200 OK\r\n",
+                                "Connection: close\r\n",
+                                "\r\n", // an empty line delimits response header from the body
+                            ]
+                            .join("")
+                            .as_bytes(),
+                        )
+                        .await
+                        .expect("cannot write response header");
+                    println!("[server] Response header sent");
+                }
+
+                if n == 0 {
+                    break;
+                }
+
+                socket
+                    .write_all(&buf[0..n])
+                    .await
+                    .expect("failed to write data to socket");
+                println!("[server] Echoed {n} bytes");
+
+                // This is not very robust. If these four bytes are split across chunk boundaries,
+                // e.g. by the underlying TCP protocol, then our detection fails.
+                if buf[0..n].ends_with(b"\r\n\r\n") {
+                    println!("[server] Detected end of request headers, stopping the echo loop");
+                    break;
+                }
+            }
+            socket
+                .shutdown()
+                .await
+                .expect("cannot shutdown incoming connection");
+            println!("[server] Request handled")
+        });
+    }
+}


### PR DESCRIPTION
Change the value sent in `User-Agent` request headers to match the agent version used to identify our libp2p node.

Modify the agent string as follows:

- CLI keeps reporting `zinnia/0.9.0` (`0.9.0` is the current version)

- Zinniad (Filecoin Station) reports the user agent as a combination of the Zinnia version plus the name of the Station module running.

  Example: `zinniad/0.9.0 dummy-module`

Resolves #76
