### PR TITLE
feat: print initial job count on `zinniad` start

### DIFF
--- a/daemon/station_reporter.rs
+++ b/daemon/station_reporter.rs
@@ -28,7 +28,7 @@ impl StationReporter {
             .unwrap()
             .total_jobs_completed;
 
-        Self {
+        let reporter = Self {
             tracker: RefCell::new(JobCompletionTracker::new(
                 initial_job_count,
                 job_report_delay,
@@ -36,7 +36,15 @@ impl StationReporter {
             module_name,
             log_target,
             state_file,
+        };
+
+        // Report the initial job count to prevent Station Desktop from showing incorrect job count
+        // until a Zinnia module completes the first job
+        if initial_job_count > 0 {
+            reporter.print_jobs_completed(initial_job_count);
         }
+
+        reporter
     }
 
     fn print_jobs_completed(&self, total: u64) {

--- a/examples/ping-probe/probe.js
+++ b/examples/ping-probe/probe.js
@@ -80,6 +80,9 @@ while (true) {
     console.error("Cannot record stats: %s", err);
   }
 
+  // Notify Filecoin Station
+  Zinnia.jobCompleted();
+
   // Wait one second before running another probe
   await sleep(1000);
 }


### PR DESCRIPTION
Announce the total number of completed jobs immediately at startup.

Before this change, we would not announce it until the first job was completed. That led to suboptimal UX: the Station initially displayed job count 0. After a while, the counter jumped to a much higher value.

With this change in place, Filecoin Station should have the right value of our job counter as soon as we load it from our persisted state.

See https://github.com/filecoin-station/core/pull/134#discussion_r1203790934
