### PR TITLE
docs: fix heading levels in building-modules

### DIFF
--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -87,6 +87,7 @@ import * as code from "../../other/code.js";
 - [Web APIs](#web-apis)
 - [Unsupported Web APIs](#unsupported-web-apis)
 - [libp2p](#libp2p)
+- [Integration with Filecoin Station](#integration-with-filecoin-station)
 - [IPFS retrieval client](#ipfs-retrieval-client)
 
 ### Standard JavaScript APIs
@@ -228,7 +229,7 @@ Tracking issue: n/a
 
 - `XMLHttpRequest` Standard
 
-## libp2p
+### libp2p
 
 Zinnia comes with a built-in libp2p node based on
 [rust-libp2p](https://github.com/libp2p/rust-libp2p). The node is shared by all Station Modules
@@ -293,7 +294,7 @@ for await (const chunk of response) {
 }
 ```
 
-#### Integration with Filecoin Station
+### Integration with Filecoin Station
 
 #### `Zinnia.walletAddress`
 


### PR DESCRIPTION
Also add a ToC entry to make it easier to find Station-related APIs.

The new structure:

<img width="360" alt="Screenshot 2023-06-21 at 17 10 38" src="https://github.com/filecoin-station/zinnia/assets/1140553/cf3697a3-3c88-4830-8383-3c49a3e2c447">

