### PR TITLE
feat: Zinnia.versions.{zinnia,v8}

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -60,13 +60,17 @@ async fn main_impl() -> Result<()> {
                 .context("cannot initialize the IPFS retrieval client Lassie")?,
             );
 
-            let config = BootstrapOptions::new(
-                format!("zinnia/{}", env!("CARGO_PKG_VERSION")),
-                Rc::new(ConsoleReporter::new(Duration::from_millis(500))),
-                lassie_daemon,
-                None,
-            );
-            run_js_module(&main_module, &config).await?;
+            let runtime_config = BootstrapOptions {
+                zinnia_version: env!("CARGO_PKG_VERSION"),
+                ..BootstrapOptions::new(
+                    format!("zinnia/{}", env!("CARGO_PKG_VERSION")),
+                    Rc::new(ConsoleReporter::new(Duration::from_millis(500))),
+                    lassie_daemon,
+                    None,
+                )
+            };
+
+            run_js_module(&main_module, &runtime_config).await?;
             Ok(())
         }
     }

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -68,25 +68,24 @@ async fn run(config: CliArgs) -> Result<()> {
     )?;
     let module_root = get_module_root(&main_module)?;
 
-    let config = BootstrapOptions {
-        agent_version: format!("zinniad/{} {module_name}", env!("CARGO_PKG_VERSION")),
-        wallet_address: config.wallet_address,
-        reporter: Rc::new(StationReporter::new(
+    let mut runtime_config = BootstrapOptions::new(
+        format!("zinniad/{} {module_name}", env!("CARGO_PKG_VERSION")),
+        Rc::new(StationReporter::new(
             state_file,
             Duration::from_millis(200),
             module_name.into(),
         )),
         lassie_daemon,
-        module_root: Some(module_root),
-        no_color: true,
-        is_tty: false,
-        rng_seed: None,
-    };
+        Some(module_root),
+    );
+    runtime_config.wallet_address = config.wallet_address;
+    runtime_config.no_color = true;
+    runtime_config.is_tty = false;
 
     // TODO: handle module exit and restart it
     // https://github.com/filecoin-station/zinnia/issues/146
     log::info!("Starting module {main_module}");
-    run_js_module(&main_module, &config).await?;
+    run_js_module(&main_module, &runtime_config).await?;
 
     Ok(())
 }

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -68,19 +68,21 @@ async fn run(config: CliArgs) -> Result<()> {
     )?;
     let module_root = get_module_root(&main_module)?;
 
-    let mut runtime_config = BootstrapOptions::new(
-        format!("zinniad/{} {module_name}", env!("CARGO_PKG_VERSION")),
-        Rc::new(StationReporter::new(
+    let runtime_config = BootstrapOptions {
+        zinnia_version: env!("CARGO_PKG_VERSION"),
+        agent_version: format!("zinniad/{} {module_name}", env!("CARGO_PKG_VERSION")),
+        wallet_address: config.wallet_address,
+        reporter: Rc::new(StationReporter::new(
             state_file,
             Duration::from_millis(200),
             module_name.into(),
         )),
         lassie_daemon,
-        Some(module_root),
-    );
-    runtime_config.wallet_address = config.wallet_address;
-    runtime_config.no_color = true;
-    runtime_config.is_tty = false;
+        module_root: Some(module_root),
+        no_color: true,
+        is_tty: false,
+        rng_seed: None,
+    };
 
     // TODO: handle module exit and restart it
     // https://github.com/filecoin-station/zinnia/issues/146

--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -93,6 +93,7 @@ import * as code from "../../other/code.js";
 - [libp2p](#libp2p)
 - [Integration with Filecoin Station](#integration-with-filecoin-station)
 - [IPFS retrieval client](#ipfs-retrieval-client)
+- [Miscelaneous APIs]()
 
 ### Standard JavaScript APIs
 
@@ -360,6 +361,16 @@ possible error status codes in
 [Lassie's HTTP Specification](https://github.com/filecoin-project/lassie/blob/main/docs/HTTP_SPEC.md).
 The format of CAR data returned by the retrieval client is described in
 [Lassie's Returned CAR Specification](https://github.com/filecoin-project/lassie/blob/main/docs/CAR.md).
+
+### Miscelaneous APIs
+
+#### `Zinnia.versions.zinna`
+
+The version of Zinnia runtime, e.g. `"0.11.0"`.
+
+#### `Zinnia.versions.v8`
+
+The version of V8 engine, e.g. `"11.5.150.2"`.
 
 ## Testing Guide
 

--- a/runtime/js/90_zinnia_apis.js
+++ b/runtime/js/90_zinnia_apis.js
@@ -1,10 +1,22 @@
 const primordials = globalThis.__bootstrap.primordials;
-const { ObjectDefineProperties, ObjectCreate } = primordials;
+const { ObjectDefineProperties, ObjectCreate, ObjectFreeze } = primordials;
 
 const { ops } = globalThis.Deno.core;
 
 import { readOnly } from "ext:zinnia_runtime/06_util.js";
 import * as libp2p from "ext:zinnia_libp2p/01_peer.js";
+
+const versions = {
+  zinnia: "",
+  v8: "",
+};
+
+function setVersions(zinniaVersion, v8Version) {
+  versions.zinnia = zinniaVersion;
+  versions.v8 = v8Version;
+
+  ObjectFreeze(versions);
+}
 
 const zinniaNs = ObjectCreate(null);
 ObjectDefineProperties(zinniaNs, libp2p.defaultPeerProps);
@@ -18,6 +30,7 @@ ObjectDefineProperties(activityApi, {
 ObjectDefineProperties(zinniaNs, {
   activity: readOnly(activityApi),
   jobCompleted: readOnly(reportJobCompleted),
+  versions: readOnly(versions),
 });
 
 function reportInfoActivity(msg) {
@@ -39,4 +52,4 @@ function log(msg, level) {
   ops.op_zinnia_log(msg, level);
 }
 
-export { zinniaNs, log };
+export { zinniaNs, log, setVersions };

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -37,6 +37,7 @@ import {
   windowOrWorkerGlobalScope,
 } from "ext:zinnia_runtime/98_global_scope.js";
 import { setLassieUrl } from "ext:zinnia_runtime/fetch.js";
+import { setVersions } from "ext:zinnia_runtime/90_zinnia_apis.js";
 
 function formatException(error) {
   if (ObjectPrototypeIsPrototypeOf(ErrorPrototype, error)) {
@@ -69,6 +70,7 @@ function runtimeStart(runtimeOptions) {
   Error.prepareStackTrace = core.prepareStackTrace;
 
   setLassieUrl(runtimeOptions.lassieUrl);
+  setVersions(runtimeOptions.zinniaVersion, runtimeOptions.v8Version);
 }
 
 let hasBootstrapped = false;

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -41,8 +41,9 @@ pub struct BootstrapOptions {
     /// the singleton Lassie instance between multiple threads spawned by Rust's test runner.
     pub lassie_daemon: Arc<lassie::Daemon>,
 
-    zinnia_version: &'static str,
-    v8_version: &'static str,
+    /// Zinnia version reported by `Zinnia.versions.zinnia` API.
+    /// Embedders can customize this value.
+    pub zinnia_version: &'static str,
 }
 
 impl BootstrapOptions {
@@ -62,9 +63,7 @@ impl BootstrapOptions {
             wallet_address: String::from("t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za"),
             reporter,
             lassie_daemon,
-            // FIXME: add ".1-dev" unless we are building a release
             zinnia_version: env!("CARGO_PKG_VERSION"),
-            v8_version: deno_core::v8_version(),
         }
     }
 
@@ -75,7 +74,7 @@ impl BootstrapOptions {
           "walletAddress": self.wallet_address,
           "lassieUrl": format!("http://127.0.0.1:{}/", self.lassie_daemon.port()),
           "zinniaVersion": self.zinnia_version,
-          "v8Version": self.v8_version,
+          "v8Version": deno_core::v8_version(),
         });
         serde_json::to_string_pretty(&payload).unwrap()
     }

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -40,6 +40,9 @@ pub struct BootstrapOptions {
     /// Lassie daemon to use as the IPFS retrieval client. We must use Arc here to allow sharing of
     /// the singleton Lassie instance between multiple threads spawned by Rust's test runner.
     pub lassie_daemon: Arc<lassie::Daemon>,
+
+    zinnia_version: &'static str,
+    v8_version: &'static str,
 }
 
 impl BootstrapOptions {
@@ -59,6 +62,9 @@ impl BootstrapOptions {
             wallet_address: String::from("t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za"),
             reporter,
             lassie_daemon,
+            // FIXME: add ".1-dev" unless we are building a release
+            zinnia_version: env!("CARGO_PKG_VERSION"),
+            v8_version: deno_core::v8_version(),
         }
     }
 
@@ -68,6 +74,8 @@ impl BootstrapOptions {
           "isTty": self.is_tty,
           "walletAddress": self.wallet_address,
           "lassieUrl": format!("http://127.0.0.1:{}/", self.lassie_daemon.port()),
+          "zinniaVersion": self.zinnia_version,
+          "v8Version": self.v8_version,
         });
         serde_json::to_string_pretty(&payload).unwrap()
     }

--- a/runtime/tests/js/versions_tests.js
+++ b/runtime/tests/js/versions_tests.js
@@ -10,7 +10,7 @@ test("Zinnia.versions", () => {
 
 test("Zinnia.versions.zinnia", () => {
   assertArrayIncludes(Object.keys(Zinnia.versions), ["zinnia"], "Zinnia.versions properties");
-  assertMatch(Zinnia.versions?.zinnia, /^\d+\.\d+\.\d+$/);
+  assertMatch(Zinnia.versions.zinnia, /^\d+\.\d+\.\d+$/);
 });
 
 test("Zinnia.versions.v8", () => {

--- a/runtime/tests/js/versions_tests.js
+++ b/runtime/tests/js/versions_tests.js
@@ -1,0 +1,19 @@
+import { test } from "zinnia:test";
+import { assertMatch, assertEquals, assertArrayIncludes } from "zinnia:assert";
+
+console.log(Zinnia.versions);
+
+test("Zinnia.versions", () => {
+  assertArrayIncludes(Object.keys(Zinnia), ["versions"], "Zinnia properties");
+  assertEquals(typeof Zinnia.versions, "object", "typeof Zinnia.versions");
+});
+
+test("Zinnia.versions.zinnia", () => {
+  assertArrayIncludes(Object.keys(Zinnia.versions), ["zinnia"], "Zinnia.versions properties");
+  assertMatch(Zinnia.versions?.zinnia, /^\d+\.\d+\.\d+$/);
+});
+
+test("Zinnia.versions.v8", () => {
+  assertArrayIncludes(Object.keys(Zinnia.versions), ["v8"], "Zinnia.versions properties");
+  assertMatch(Zinnia.versions.v8, /^\d+\.\d+\.\d+\.\d+$/);
+});

--- a/runtime/tests/runtime_integration_tests.rs
+++ b/runtime/tests/runtime_integration_tests.rs
@@ -82,6 +82,7 @@ macro_rules! test_runner_tests(
 );
 
 js_tests!(globals_tests);
+js_tests!(versions_tests);
 js_tests!(timers_tests);
 js_tests!(webapis_tests);
 js_tests!(webcrypto_tests);


### PR DESCRIPTION
Add a new Zinnia API exposing runtime and V8 versions to modules.

Related: https://github.com/filecoin-station/spark-api/pull/29

In the future, we can expose this via `import versions from "zinnia:versions"` - see #236.
