### PR TITLE
fix: relax timer test timeout

### DIFF
--- a/runtime/tests/js/timers_tests.js
+++ b/runtime/tests/js/timers_tests.js
@@ -6,7 +6,7 @@ await new Promise((resolve) => {
 
 const duration = Date.now() - start;
 const min = 40;
-const max = 120;
+const max = 300;
 
 if (duration < min || duration > max) {
   throw new Error(


### PR DESCRIPTION
https://github.com/filecoin-station/zinnia/actions/runs/5374177743/jobs/9749361834?pr=264

> Error: Error: setTimeout(50) should take between 40 to 120 ms to execute, but took 208 ms instead