### PR TITLE
feat: secure Lassie server using authorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "lassie"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996778d3f1be80d0d1152d20bf05476ef16c0ba6e163580230bd04b5744b4891"
+checksum = "205d4b3140054548c1ddbf689bb961a60947a5b2290e8a8920524a02519c28f6"
 dependencies = [
  "cc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5786,6 +5786,7 @@ name = "zinniad"
 version = "0.12.0"
 dependencies = [
  "assert_cmd",
+ "assert_fs",
  "atomicwrites",
  "clap",
  "env_logger",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,7 @@ assert_fs = { workspace = true }
 lazy_static = "1.4.0"
 pretty_assertions = { workspace = true }
 regex = "1.8.4"
+tokio = { workspace = true, features = ["io-util"] }
 
 [package.metadata.winres]
 # This section defines the metadata that appears in the deno.exe PE header.

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -41,8 +41,7 @@ async fn main_impl() -> Result<()> {
 
 #[allow(dead_code)]
 struct RunOutput {
-    // TBD
-    module_result: (),
+    module_output: (),
     // for testing
     lassie_daemon: Arc<lassie::Daemon>,
 }
@@ -91,10 +90,11 @@ async fn run_module(file: String) -> Result<RunOutput> {
         )
     };
 
-    run_js_module(&main_module, &runtime_config).await?;
+    #[allow(clippy::let_unit_value)]
+    let module_output = run_js_module(&main_module, &runtime_config).await?;
 
     Ok(RunOutput {
-        module_result: (),
+        module_output,
         lassie_daemon,
     })
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -130,7 +130,7 @@ mod tests {
             assert_fs::NamedTempFile::new("dummy.js").expect("cannot create temp dummy.js");
 
         mod_js
-            .write_str(&format!("/* no-op */",))
+            .write_str("/* no-op */")
             .expect("cannot write to dummy.js");
 
         let RunOutput { lassie_daemon, .. } =

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -32,53 +32,71 @@ async fn main_impl() -> Result<()> {
     let cli_args = CliArgs::parse_from(std::env::args());
     match cli_args.command {
         Commands::Run { file } => {
-            let main_module = resolve_path(
-                &file,
-                &std::env::current_dir().context("unable to get current working directory")?,
-            )?;
+            run_module(file).await?;
 
-            let lassie_daemon = Arc::new(
-                lassie::Daemon::start(lassie::DaemonConfig {
-                    // This configuration applies to `zinnia` CLI only. The `zinniad` daemon running
-                    // inside Station uses a different temp_dir config based on the env var
-                    // `CACHE_ROOT` provided by the Station.
-                    //
-                    // By default, Lassie stores its temporary files in the system temp directory.
-                    // That's good enough for now. We can improve this later based on user feedback,
-                    // for example:
-                    // - we can honour CACHE_ROOT
-                    // - we can default to something like
-                    //   `~/.cache/zinnia/lassie` on Unix,
-                    //   `%APPLOCALDATA%\zinnia\lassie' on Windows.
-                    //
-                    // Important: if we tell Lassie to use a specific temp dir that's not
-                    // automatically cleaned by the operating system, we will need to clean any
-                    // leftover files ourselves. See the GH issue for deleting leftover files
-                    // when `zinniad` starts: https://github.com/filecoin-station/zinnia/issues/245
-                    temp_dir: None,
-                    // Listen on an ephemeral port selected by the operating system
-                    port: 0,
-                    access_token: Some(generate_lassie_access_token()),
-                    // Use the default Lassie configuration for everything else
-                    ..lassie::DaemonConfig::default()
-                })
-                .context("cannot initialize the IPFS retrieval client Lassie")?,
-            );
-
-            let runtime_config = BootstrapOptions {
-                zinnia_version: env!("CARGO_PKG_VERSION"),
-                ..BootstrapOptions::new(
-                    format!("zinnia/{}", env!("CARGO_PKG_VERSION")),
-                    Rc::new(ConsoleReporter::new(Duration::from_millis(500))),
-                    lassie_daemon,
-                    None,
-                )
-            };
-
-            run_js_module(&main_module, &runtime_config).await?;
             Ok(())
         }
     }
+}
+
+#[allow(dead_code)]
+struct RunOutput {
+    // TBD
+    module_result: (),
+    // for testing
+    lassie_daemon: Arc<lassie::Daemon>,
+}
+
+async fn run_module(file: String) -> Result<RunOutput> {
+    let main_module = resolve_path(
+        &file,
+        &std::env::current_dir().context("unable to get current working directory")?,
+    )?;
+
+    let lassie_daemon = Arc::new(
+        lassie::Daemon::start(lassie::DaemonConfig {
+            // This configuration applies to `zinnia` CLI only. The `zinniad` daemon running
+            // inside Station uses a different temp_dir config based on the env var
+            // `CACHE_ROOT` provided by the Station.
+            //
+            // By default, Lassie stores its temporary files in the system temp directory.
+            // That's good enough for now. We can improve this later based on user feedback,
+            // for example:
+            // - we can honour CACHE_ROOT
+            // - we can default to something like
+            //   `~/.cache/zinnia/lassie` on Unix,
+            //   `%APPLOCALDATA%\zinnia\lassie' on Windows.
+            //
+            // Important: if we tell Lassie to use a specific temp dir that's not
+            // automatically cleaned by the operating system, we will need to clean any
+            // leftover files ourselves. See the GH issue for deleting leftover files
+            // when `zinniad` starts: https://github.com/filecoin-station/zinnia/issues/245
+            temp_dir: None,
+            // Listen on an ephemeral port selected by the operating system
+            port: 0,
+            access_token: Some(generate_lassie_access_token()),
+            // Use the default Lassie configuration for everything else
+            ..lassie::DaemonConfig::default()
+        })
+        .context("cannot initialize the IPFS retrieval client Lassie")?,
+    );
+
+    let runtime_config = BootstrapOptions {
+        zinnia_version: env!("CARGO_PKG_VERSION"),
+        ..BootstrapOptions::new(
+            format!("zinnia/{}", env!("CARGO_PKG_VERSION")),
+            Rc::new(ConsoleReporter::new(Duration::from_millis(500))),
+            Arc::clone(&lassie_daemon),
+            None,
+        )
+    };
+
+    run_js_module(&main_module, &runtime_config).await?;
+
+    Ok(RunOutput {
+        module_result: (),
+        lassie_daemon,
+    })
 }
 
 fn exit_with_error(error: Error) {
@@ -97,4 +115,59 @@ fn exit_with_error(error: Error) {
         error_string.trim_start_matches("error: ")
     );
     std::process::exit(error_code);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_fs::prelude::*;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    #[tokio::test]
+    async fn lassie_auth_is_configured() {
+        // Step 1: execute `zinnia run` with a dummy module that does nothing
+        let mod_js =
+            assert_fs::NamedTempFile::new("dummy.js").expect("cannot create temp dummy.js");
+
+        mod_js
+            .write_str(&format!("/* no-op */",))
+            .expect("cannot write to dummy.js");
+
+        let RunOutput { lassie_daemon, .. } =
+            run_module(mod_js.path().to_string_lossy().to_string())
+                .await
+                .expect("cannot run dummy.js");
+
+        assert!(
+            lassie_daemon.access_token().is_some(),
+            "lassie_daemon access_token was not set"
+        );
+
+        // Make a retrieval request to Lassie but do not provide any access token
+        let mut stream =
+            tokio::net::TcpStream::connect(format!("127.0.0.1:{}", lassie_daemon.port()))
+                .await
+                .expect("cannot connect to Lassie HTTP daemon");
+
+        stream
+            .write_all(
+                concat!(
+                "GET /ipfs/bafybeib36krhffuh3cupjml4re2wfxldredkir5wti3dttulyemre7xkni HTTP/1.1\n",
+                "Host: 127.0.0.1\n",
+                "\n",
+                )
+                .as_bytes(),
+            )
+            .await
+            .expect("cannot write HTTP request");
+
+        let status = BufReader::new(stream)
+            .lines()
+            .next_line()
+            .await
+            .expect("cannot read the first line of the HTTP response")
+            .expect("server returned at least one line");
+
+        assert_eq!(status, "HTTP/1.1 401 Unauthorized")
+    }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -11,7 +11,8 @@ use zinnia_runtime::anyhow::{Context, Error, Result};
 use zinnia_runtime::deno_core::error::JsError;
 use zinnia_runtime::fmt_errors::format_js_error;
 use zinnia_runtime::{
-    colors, lassie, resolve_path, run_js_module, BootstrapOptions, ConsoleReporter,
+    colors, generate_lassie_access_token, lassie, resolve_path, run_js_module, BootstrapOptions,
+    ConsoleReporter,
 };
 
 #[tokio::main(flavor = "current_thread")]
@@ -57,6 +58,7 @@ async fn main_impl() -> Result<()> {
                     temp_dir: None,
                     // Listen on an ephemeral port selected by the operating system
                     port: 0,
+                    access_token: Some(generate_lassie_access_token()),
                     // Use the default Lassie configuration for everything else
                     ..lassie::DaemonConfig::default()
                 })

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -25,5 +25,6 @@ zinnia_runtime = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
+assert_fs = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile = "3.6.0"

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -94,18 +94,18 @@ async fn run(config: CliArgs) -> Result<RunOutput> {
     // TODO: handle module exit and restart it
     // https://github.com/filecoin-station/zinnia/issues/146
     log::info!("Starting module {main_module}");
-    run_js_module(&main_module, &runtime_config).await?;
+    #[allow(clippy::let_unit_value)]
+    let module_output = run_js_module(&main_module, &runtime_config).await?;
 
     Ok(RunOutput {
-        module_result: (),
+        module_output,
         lassie_daemon,
     })
 }
 
 #[allow(dead_code)]
 struct RunOutput {
-    // TBD
-    module_result: (),
+    module_output: (),
     // for testing
     lassie_daemon: Arc<lassie::Daemon>,
 }

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -12,7 +12,10 @@ use args::CliArgs;
 use clap::Parser;
 
 use zinnia_runtime::anyhow::{anyhow, Context, Error, Result};
-use zinnia_runtime::{get_module_root, lassie, resolve_path, run_js_module, BootstrapOptions};
+use zinnia_runtime::{
+    generate_lassie_access_token, get_module_root, lassie, resolve_path, run_js_module,
+    BootstrapOptions,
+};
 
 use crate::station_reporter::{log_info_activity, StationReporter};
 
@@ -49,6 +52,7 @@ async fn run(config: CliArgs) -> Result<()> {
         temp_dir: Some(lassie_temp_dir),
         // Listen on an ephemeral port selected by the operating system
         port: 0,
+        access_token: Some(generate_lassie_access_token()),
         // Use the default Lassie configuration for everything else
         ..lassie::DaemonConfig::default()
     };

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -174,7 +174,7 @@ mod tests {
             assert_fs::NamedTempFile::new("dummy.js").expect("cannot create temp dummy.js");
 
         mod_js
-            .write_str(&format!("/* no-op */",))
+            .write_str("/* no-op */")
             .expect("cannot write to dummy.js");
 
         let temp = assert_fs::TempDir::new().expect("cannot create a new temp directory");

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,7 +21,7 @@ deno_fetch = "0.132.0"
 deno_url = "0.108.0"
 deno_web = "0.139.0"
 deno_webidl = "0.108.0"
-lassie = "0.4.0"
+lassie = "0.5.1"
 # lassie = { git = "https://github.com/filecoin-station/rusty-lassie.git" }
 log.workspace = true
 once_cell = "1.18.0"

--- a/runtime/js/99_main.js
+++ b/runtime/js/99_main.js
@@ -36,7 +36,7 @@ import {
   mainRuntimeGlobalProperties,
   windowOrWorkerGlobalScope,
 } from "ext:zinnia_runtime/98_global_scope.js";
-import { setLassieUrl } from "ext:zinnia_runtime/fetch.js";
+import { setLassieConfig } from "ext:zinnia_runtime/fetch.js";
 import { setVersions } from "ext:zinnia_runtime/90_zinnia_apis.js";
 
 function formatException(error) {
@@ -69,7 +69,7 @@ function runtimeStart(runtimeOptions) {
   // deno-lint-ignore prefer-primordials
   Error.prepareStackTrace = core.prepareStackTrace;
 
-  setLassieUrl(runtimeOptions.lassieUrl);
+  setLassieConfig(runtimeOptions.lassieUrl, runtimeOptions.lassieAuth);
   setVersions(runtimeOptions.zinniaVersion, runtimeOptions.v8Version);
 }
 

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -73,6 +73,10 @@ impl BootstrapOptions {
           "isTty": self.is_tty,
           "walletAddress": self.wallet_address,
           "lassieUrl": format!("http://127.0.0.1:{}/", self.lassie_daemon.port()),
+          "lassieAuth": match self.lassie_daemon.access_token() {
+            Some(token) => serde_json::Value::String(format!("Bearer {token}")),
+            None => serde_json::Value::Null,
+          },
           "zinniaVersion": self.zinnia_version,
           "v8Version": deno_core::v8_version(),
         });
@@ -131,4 +135,15 @@ pub async fn run_js_module(
     zinnia_libp2p::shutdown(runtime.op_state()).await?;
 
     Ok(())
+}
+
+use deno_crypto::rand::{self, distributions::Alphanumeric, Rng};
+
+/// A helper function to generate an access token for protecting Lassie's HTTP API
+pub fn generate_lassie_access_token() -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(24)
+        .map(char::from)
+        .collect()
 }

--- a/runtime/tests/helpers/mod.rs
+++ b/runtime/tests/helpers/mod.rs
@@ -1,11 +1,18 @@
 use std::sync::{Arc, OnceLock};
 
+use zinnia_runtime::generate_lassie_access_token;
+
 pub fn lassie_daemon() -> Arc<lassie::Daemon> {
     static LASSIE_DAEMON: OnceLock<Result<Arc<lassie::Daemon>, lassie::StartError>> =
         OnceLock::new();
 
-    let result = LASSIE_DAEMON
-        .get_or_init(|| lassie::Daemon::start(lassie::DaemonConfig::default()).map(Arc::new));
+    let result = LASSIE_DAEMON.get_or_init(|| {
+        lassie::Daemon::start(lassie::DaemonConfig {
+            access_token: Some(generate_lassie_access_token()),
+            ..lassie::DaemonConfig::default()
+        })
+        .map(Arc::new)
+    });
 
     match result {
         Ok(ptr) => Arc::clone(ptr),

--- a/runtime/tests/js/ipfs_retrieval_tests.js
+++ b/runtime/tests/js/ipfs_retrieval_tests.js
@@ -1,5 +1,5 @@
 import { test } from "zinnia:test";
-import { assertEquals, AssertionError } from "zinnia:assert";
+import { assertEquals, assertMatch, assertRejects, AssertionError } from "zinnia:assert";
 
 const EXPECTED_CAR_BASE64 =
   "OqJlcm9vdHOB2CpYJQABcBIgO/KicpaH2Kj0sXyJNWLdY4kGpEe2mjY5zovBGRJ+6mpndmVyc2lvbgFrAXASIDvyonKWh9io9LF8iTVi3WOJBqRHtpo2Oc6LwRkSfupqCkUIAhI/TXkgbW9zdCBmYW1vdXMgZHJhd2luZywgYW5kIG9uZSBvZiB0aGUgZmlyc3QgSSBkaWQgZm9yIHRoZSBzaXRlGD8=";
@@ -7,7 +7,7 @@ const EXPECTED_CAR_BASE64 =
 test("can retrieve CID content as a CAR file", async () => {
   const requestUrl = "ipfs://bafybeib36krhffuh3cupjml4re2wfxldredkir5wti3dttulyemre7xkni";
   const response = await fetch(requestUrl);
-  assertResponseIsOk(response);
+  await assertResponseIsOk(response);
 
   const payload = await response.arrayBuffer();
   assertEquals(payload.byteLength, 167, "CAR size in bytes");
@@ -21,7 +21,7 @@ test("can retrieve CID content as a CAR file", async () => {
 test("can retrieve IPFS content using URL", async () => {
   const requestUrl = new URL("ipfs://bafybeib36krhffuh3cupjml4re2wfxldredkir5wti3dttulyemre7xkni");
   const response = await fetch(requestUrl);
-  assertResponseIsOk(response);
+  await assertResponseIsOk(response);
 
   const payload = await response.arrayBuffer();
   assertEquals(payload.byteLength, 167, "CAR size in bytes");
@@ -32,12 +32,55 @@ test("can retrieve IPFS content using URL", async () => {
 test("can retrieve IPFS content using Fetch Request object", async () => {
   const request = new Request("ipfs://bafybeib36krhffuh3cupjml4re2wfxldredkir5wti3dttulyemre7xkni");
   const response = await fetch(request);
-  assertResponseIsOk(response);
+  await assertResponseIsOk(response);
 
   const payload = await response.arrayBuffer();
   assertEquals(payload.byteLength, 167, "CAR size in bytes");
 
   assertEquals(response.url, request.url);
+});
+
+test("does not modify original request headers - headers initialized as array", async () => {
+  const request = new Request(
+    "ipfs://bafybeib36krhffuh3cupjml4re2wfxldredkir5wti3dttulyemre7xkni",
+    { headers: [["X-Test", "true"]] },
+  );
+  const response = await fetch(request);
+  await assertResponseIsOk(response);
+
+  assertEquals(Array.from(request.headers.keys()), ["x-test"]);
+});
+
+test("does not modify original request headers - headers initialized as object", async () => {
+  const request = new Request(
+    "ipfs://bafybeib36krhffuh3cupjml4re2wfxldredkir5wti3dttulyemre7xkni",
+    { headers: { "X-Test": "true" } },
+  );
+  const response = await fetch(request);
+  await assertResponseIsOk(response);
+
+  assertEquals(Array.from(request.headers.keys()), ["x-test"]);
+});
+
+test("does not modify original request headers - headers initialized as Headers", async () => {
+  const request = new Request(
+    "ipfs://bafybeib36krhffuh3cupjml4re2wfxldredkir5wti3dttulyemre7xkni",
+    { headers: new Headers({ "X-Test": "true" }) },
+  );
+  const response = await fetch(request);
+  await assertResponseIsOk(response);
+
+  assertEquals(Array.from(request.headers.keys()), ["x-test"]);
+});
+
+test("rejects user-provided Authorization header", async () => {
+  const request = new Request(
+    "ipfs://bafybeib36krhffuh3cupjml4re2wfxldredkir5wti3dttulyemre7xkni",
+    { headers: { Authorization: "invalid" } },
+  );
+
+  let error = await assertRejects(() => fetch(request));
+  assertMatch(error.message, /authorization/i);
 });
 
 /**


### PR DESCRIPTION
Configure Lassie HTTP server to require authorization with the configured access token.

This change does not affect Zinnia modules with one exception: `fetch('ipfs://`) requests are not allowed to send an `Authorization` header now.

Also upgrade Lassie from v0.4.0 to v0.5.1. Release notes: 
- https://github.com/filecoin-station/rusty-lassie/releases/tag/v0.5.0
- https://github.com/filecoin-station/rusty-lassie/releases/tag/v0.5.1
