### PR TITLE
ci: use Go version 1.20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: stable
+          go-version: '1.20'
           cache: false # caching requires a go.sum file, which we don't have in our project
 
       - uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e # v1
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: stable
+          go-version: '1.20'
           cache: false # caching requires a go.sum file, which we don't have in our project
 
       - uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e # v1
@@ -112,7 +112,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: stable
+          go-version: '1.20'
           cache: false # caching requires a go.sum file, which we don't have in our project
 
       - uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e # v1
@@ -154,7 +154,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: stable
+          go-version: '1.20'
           cache: false # caching requires a go.sum file, which we don't have in our project
 
       - uses: dtolnay/rust-toolchain@0e66bd3e6b38ec0ad5312288c83e47c143e6b09e # v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: stable
+          go-version: '1.20'
           cache: false # caching requires a go.sum file, which we don't have in our project
 
       - name: Setup | Rust


### PR DESCRIPTION
rusty-lassie doesn't support Go version 1.21 yet.

See also https://github.com/filecoin-station/rusty-lassie/pull/53
