### PR TITLE
deps: upgrade Deno to 1.36.3 / 2023.08.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,12 +587,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-modes"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2211b0817f061502a8dd9f11a37e879e79763e3c698d2418cf824d8cb2f21e"
-
-[[package]]
 name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +798,15 @@ name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1074,23 +1077,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
 
 [[package]]
-name = "deno_console"
-version = "0.108.0"
+name = "deno-proc-macro-rules"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d8ba61442961d84a85029ed7caf940ff417f94083c1ec4a804d99f7a8e1f28"
+checksum = "3c65c2ffdafc1564565200967edc4851c7b55422d3913466688907efd05ea26f"
+dependencies = [
+ "deno-proc-macro-rules-macros",
+ "proc-macro2",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "deno-proc-macro-rules-macros"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3047b312b7451e3190865713a4dd6e1f821aed614ada219766ebc3024a690435"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "deno_console"
+version = "0.117.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6816a89834b97c8a3cc0278a824aff6af42fc5a0fad5af74b47758143f5597"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.190.0"
+version = "0.204.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874134a910db7ce562244ea1ed1c5efec42fdd7613b34025c2fc46505deb5db"
+checksum = "b4ddf51deb9a3bb60a4ab74784414b3f2f89de83a77d6d90a64c6447f7765d68"
 dependencies = [
  "anyhow",
  "bytes",
  "deno_ops",
+ "deno_unsync",
  "futures",
  "indexmap 1.9.3",
  "libc",
@@ -1110,15 +1137,14 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto"
-version = "0.122.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2e48c8b709828a196a3edf981b22d00a739ef3aaaf7daae379da3e9d47785f"
+checksum = "24a66c6cd7f673ccea6277e381dbdfceddaff47946b3de5a08f19c60d65b819e"
 dependencies = [
  "aes 0.8.2",
  "aes-gcm 0.10.2",
  "aes-kw",
  "base64 0.13.1",
- "block-modes 0.9.1",
  "cbc",
  "const-oid",
  "ctr 0.9.2",
@@ -1147,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "deno_fetch"
-version = "0.132.0"
+version = "0.141.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf8b4727fdfb6161ca448473328f82ded9c3ac23e8cbe00ac1f5eefdab2fee7"
+checksum = "9ae96c7d7d6c80ccc7f4daa1226a03999e939782cf1acbd50bf7f17f2865e067"
 dependencies = [
  "bytes",
  "data-url",
@@ -1160,16 +1186,16 @@ dependencies = [
  "reqwest",
  "serde",
  "tokio",
- "tokio-stream",
  "tokio-util",
 ]
 
 [[package]]
 name = "deno_ops"
-version = "0.68.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fcc21a49a44b972f54ec5f300e1e52fb386688f59fbf1734e47a69328338b8"
+checksum = "1b660872f9a9737d3424470483dd6730d2129481af5055449a2a37ab5bc2145e"
 dependencies = [
+ "deno-proc-macro-rules",
  "lazy-regex",
  "once_cell",
  "pmutil",
@@ -1177,14 +1203,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
+ "strum",
+ "strum_macros",
  "syn 1.0.109",
+ "syn 2.0.28",
+ "thiserror",
 ]
 
 [[package]]
 name = "deno_tls"
-version = "0.95.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1f710f9f42c68e0568f7e95848a789e19d019cff3d26f6c96867db8e5ca788"
+checksum = "46d7fca728761be0d4967718b76d62ad28e195b081b86afc4d97869f28c63c47"
 dependencies = [
  "deno_core",
  "once_cell",
@@ -1197,28 +1227,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "deno_url"
-version = "0.108.0"
+name = "deno_unsync"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8240b5e47b6a97e68a64db82492719d83516e2ab292875ae4b7e635a6676e7"
+checksum = "ac0984205f25e71ddd1be603d76e70255953c12ff864707359ab195d26dfc7b3"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "deno_url"
+version = "0.117.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0fcf975acf4342fea5edb42a5428b01578c3a8633668ee75466841200920a4"
 dependencies = [
  "deno_core",
  "serde",
- "serde_repr",
  "urlpattern",
 ]
 
 [[package]]
 name = "deno_web"
-version = "0.139.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbfcfecf1b546b542d31ff776399fe0045164fe7f1b7c05d784f58b4c76cdff"
+checksum = "cc0360a43b4085665375977f1a15f8fad65dd8885de141984aded1c91ce1d9d1"
 dependencies = [
  "async-trait",
  "base64-simd",
+ "bytes",
  "deno_core",
  "encoding_rs",
  "flate2",
+ "futures",
  "serde",
  "tokio",
  "uuid",
@@ -1227,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.108.0"
+version = "0.117.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0e30e2bf5df141b9dac6f43137104f1f7174033122d5c2c6fd4a352ad25fca"
+checksum = "948886d012859b5307003270a23e3597a16cf45b8bcf142c0b6512aed17216bd"
 dependencies = [
  "deno_core",
 ]
@@ -1551,12 +1591,13 @@ checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.5.4",
+ "libz-ng-sys",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -2739,6 +2780,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-ng-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dd9f43e75536a46ee0f92b758f6b63846e594e86638c61a9251338a65baea63"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2843,18 +2894,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -3337,13 +3388,13 @@ checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "pmutil"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
+checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3986,6 +4037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "rw-stream-sink"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4191,9 +4248,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.101.0"
+version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613ea53a4a3a9abe264072a12989a67cf8988619e189fd5d1220dbe18e366d04"
+checksum = "36f6cc041512391aabdae4dd11d51e370824ea35bfe896fb2585b6792e28c9bf"
 dependencies = [
  "bytes",
  "derive_more",
@@ -4366,6 +4423,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.28",
+]
 
 [[package]]
 name = "stun"
@@ -4615,17 +4694,6 @@ dependencies = [
  "either",
  "futures-util",
  "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
-dependencies = [
- "futures-core",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -4939,9 +5007,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.73.0"
+version = "0.74.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bd3f04ba5065795dae6e3db668ff0b628920fbd2e39c1755e9b62d93660c3c"
+checksum = "2eedac634b8dd39b889c5b62349cbc55913780226239166435c5cf66771792ea"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",
@@ -5243,7 +5311,7 @@ dependencies = [
  "aes-gcm 0.10.2",
  "async-trait",
  "bincode",
- "block-modes 0.7.0",
+ "block-modes",
  "byteorder",
  "ccm",
  "curve25519-dalek 3.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/filecoin-station/zinnia"
 [workspace.dependencies]
 assert_cmd = "2.0.12"
 assert_fs = "1.0.13"
-deno_core = "0.190.0"
+deno_core = "0.204.0"
 log = "0.4.17"
 pretty_assertions = "1.4.0"
 env_logger = "0.10.0"

--- a/ext/libp2p/lib.rs
+++ b/ext/libp2p/lib.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use deno_core::anyhow::{anyhow, Context, Result};
 use deno_core::error::AnyError;
-use deno_core::{op, OpState, ZeroCopyBuf};
+use deno_core::{op, JsBuffer, OpState};
 use libp2p::identity::PeerId;
 use libp2p::multiaddr::Protocol;
 use libp2p::Multiaddr;
@@ -58,7 +58,7 @@ pub async fn op_p2p_request_protocol(
     state: Rc<RefCell<OpState>>,
     remote_address: String,
     protocol_name: String,
-    request_payload: ZeroCopyBuf,
+    request_payload: JsBuffer,
 ) -> Result<Vec<u8>> {
     let mut peer_addr: Multiaddr = remote_address
         .parse()

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,13 +14,13 @@ path = "lib.rs"
 [dependencies]
 atty = "0.2.14"
 chrono = { version= "0.4.26", default-features = false, features = [ "clock", "std" ] }
-deno_console = "0.108.0"
+deno_console = "0.117.0"
 deno_core.workspace = true
-deno_crypto = "0.122.0"
-deno_fetch = "0.132.0"
-deno_url = "0.108.0"
-deno_web = "0.139.0"
-deno_webidl = "0.108.0"
+deno_crypto = "0.131.0"
+deno_fetch = "0.141.0"
+deno_url = "0.117.0"
+deno_web = "0.148.0"
+deno_webidl = "0.117.0"
 lassie = "0.5.1"
 # lassie = { git = "https://github.com/filecoin-station/rusty-lassie.git" }
 log.workspace = true

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -89,7 +89,7 @@ pub async fn run_js_module(
     module_specifier: &ModuleSpecifier,
     bootstrap_options: &BootstrapOptions,
 ) -> Result<(), AnyError> {
-    let blob_store = BlobStore::default();
+    let blob_store = Arc::new(BlobStore::default());
     let reporter = Rc::clone(&bootstrap_options.reporter);
 
     // Initialize a runtime instance

--- a/runtime/tests/fetch_api_tests.rs
+++ b/runtime/tests/fetch_api_tests.rs
@@ -77,7 +77,7 @@ async fn echo_server(listener: TcpListener) {
                     header_sent = true;
                     socket
                         .write_all(
-                            vec![
+                            [
                                 "HTTP/1.1 200 OK\r\n",
                                 "Connection: close\r\n",
                                 "\r\n", // an empty line delimits response header from the body


### PR DESCRIPTION
- bump `deno_core` to 0.204.0, the version used by other deno crates
- bump other deno crates to version 1.36.3 / 2023.08.24
  https://github.com/denoland/deno/releases/tag/v1.36.3

Notably, this fixes builds using recent rust versions (e.g. 1.72.0).