### PR TITLE
deps: upgrade Deno to 1.36.4 / 2023.09.01

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
@@ -101,7 +101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
 dependencies = [
  "aead 0.5.2",
- "aes 0.8.2",
+ "aes 0.8.3",
  "cipher 0.4.4",
  "ctr 0.9.2",
  "ghash 0.5.0",
@@ -114,7 +114,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
 dependencies = [
- "aes 0.8.2",
+ "aes 0.8.3",
 ]
 
 [[package]]
@@ -1135,11 +1135,11 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto"
-version = "0.131.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a66c6cd7f673ccea6277e381dbdfceddaff47946b3de5a08f19c60d65b819e"
+checksum = "39deb9b4cadcb1a7a98138ac34fadf5389bd2fee4b4e8e8c3f6333c09efea89e"
 dependencies = [
- "aes 0.8.2",
+ "aes 0.8.3",
  "aes-gcm 0.10.2",
  "aes-kw",
  "base64 0.13.1",
@@ -1246,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.148.0"
+version = "0.149.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc0360a43b4085665375977f1a15f8fad65dd8885de141984aded1c91ce1d9d1"
+checksum = "c183739430b71fd42f6edee0303f13f01b31e9cf80844157b7ca37b91e369275"
 dependencies = [
  "async-trait",
  "base64-simd",
@@ -1491,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,10 +16,10 @@ atty = "0.2.14"
 chrono = { version= "0.4.28", default-features = false, features = [ "clock", "std" ] }
 deno_console = "0.118.0"
 deno_core.workspace = true
-deno_crypto = "0.131.0"
+deno_crypto = "0.132.0"
 deno_fetch = "0.142.0"
 deno_url = "0.118.0"
-deno_web = "0.148.0"
+deno_web = "0.149.0"
 deno_webidl = "0.118.0"
 lassie = "0.6.0"
 # lassie = { git = "https://github.com/filecoin-station/rusty-lassie.git" }


### PR DESCRIPTION
This also fixes the webpki-related vulnerability for Fetch API.
The vulnerability is still affecting libp2p, though.

