### PR TITLE
chore: move lint config to Cargo.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,4 +9,4 @@ rustflags = [
 # Temporary solution to have clippy config in a single place until
 # Cargo and/or Clippy supports lint config file.
 # See https://github.com/rust-lang/rust-clippy/blob/8a9860901f0ae9782ff23fb793838a16f733a60b/book/src/development/proposals/roadmap-2021.md#lintstoml-configuration
-custom-clippy = "clippy --workspace --all-features --all-targets -- -A clippy::type_complexity -A clippy::pedantic -D warnings"
+custom-clippy = "clippy --workspace --all-features --all-targets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,10 @@ codegen-units = 1
 opt-level = "z"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace.lints.rust]
+warnings="deny"
+
+[workspace.lints.clippy]
+type_complexity="allow"
+pedantic="allow"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,3 +36,5 @@ LegalCopyright = "© Protocol Labs & Zinnia contributors. Permissive License Sta
 ProductName = "Filecoin Station"
 FileDescription = "Zinnia: Secure sandboxed runtime for Filecoin Station modules."
 
+[lints]
+workspace = true

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -28,3 +28,6 @@ assert_cmd = { workspace = true }
 assert_fs = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile = "3.8.1"
+
+[lints]
+workspace = true

--- a/ext/libp2p/Cargo.toml
+++ b/ext/libp2p/Cargo.toml
@@ -66,3 +66,6 @@ env_logger.workspace = true
 rand = "0.8.5"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lints]
+workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -37,3 +37,6 @@ console_static_text = "0.8.1"
 env_logger.workspace = true
 pretty_assertions = { workspace = true }
 regex = "1.10.2"
+
+[lints]
+workspace = true


### PR DESCRIPTION
See https://doc.rust-lang.org/stable/cargo/reference/workspaces.html#the-lints-table
