### PR TITLE
feat: upgrade Lassie to v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1914,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "lassie"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e507939723b8c97b0ab85d300b72864f9c548b2930d7905089e5441263e0d48"
+checksum = "6f7526ea826091192f0fb73b1d0a5ee38339867bcf7dd6b4323a992dcd317a9b"
 dependencies = [
  "cc",
  "log",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,7 +21,7 @@ deno_fetch = "0.148.0"
 deno_url = "0.124.0"
 deno_web = "0.155.0"
 deno_webidl = "0.124.0"
-lassie = "0.7.0"
+lassie = "0.8.0"
 # lassie = { git = "https://github.com/filecoin-station/rusty-lassie.git" }
 log.workspace = true
 once_cell = "1.19.0"


### PR DESCRIPTION
Configure Lassie's user agent to report Go Lassie version plus our custom suffix, e.g. `lassie/v0.21.0-rs`.

Full release notes:
https://github.com/filecoin-station/rusty-lassie/releases/tag/v0.8.0
