### PR TITLE
feat: `activity:started` event

### DIFF
--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -16,7 +16,7 @@ use zinnia_runtime::{
     get_module_root, lassie, lassie_config, resolve_path, run_js_module, BootstrapOptions,
 };
 
-use crate::station_reporter::{log_info_activity, StationReporter};
+use crate::station_reporter::{log_started_activity, StationReporter};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
@@ -56,7 +56,7 @@ async fn run(config: CliArgs) -> Result<RunOutput> {
             .context("cannot initialize the IPFS retrieval client Lassie")?,
     );
 
-    log_info_activity("Zinnia started");
+    log_started_activity();
 
     let file = &config.files[0];
 

--- a/daemon/station_reporter.rs
+++ b/daemon/station_reporter.rs
@@ -71,6 +71,15 @@ fn print_event(data: &serde_json::Value) {
         });
 }
 
+pub fn log_started_activity() {
+    let event = json!({
+        "type": "activity:started",
+        "module": serde_json::Value::Null,
+    });
+    print_event(&event);
+}
+
+#[allow(unused)]
 pub fn log_info_activity(msg: &str) {
     let event = json!({
         "type": "activity:info",


### PR DESCRIPTION
Add a new activity event to report when the runtime started. We can expose
this new event in the JS API for Station Modules in the future too.

Example output:

```
{"type":"activity:started","module":null}
{"type":"jobs-completed","total":5,"modules":{"main":5}}
```

See https://github.com/filecoin-station/core/pull/327#discussion_r1474361506
