### PR TITLE
ci: use M1 macOS runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-14
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-14
           - target: x86_64-pc-windows-msvc
             os: windows-latest
           - target: x86_64-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,11 @@ jobs:
           #   builder: cross
 
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-14
             name: macos-x64.zip
 
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-14
             name: macos-arm64.zip
 
           - target: x86_64-pc-windows-msvc


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
