### PR TITLE
ci: make release builds agnostic of runner version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup | Apple codesign
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os,  'macos-')
         env:
           LOCAL_KEYCHAIN_PASSWORD: ${{ secrets.LOCAL_KEYCHAIN_PASSWORD }}
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
@@ -127,14 +127,14 @@ jobs:
       # problem, we remove the cached Lassie version to force `cargo build` to re-run the build
       # script, which will copy `golassie.dll`.
       - name: Debugging | Force rebuild of Lassie
-        if: ${{ !startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows-latest' }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os,  'windows-') }}
         run:  cargo clean --release --target ${{ matrix.target }} -p lassie
 
       - name: Build | Build
         run: ${{ matrix.builder || 'cargo' }} build --release --locked --target ${{ matrix.target }}
 
       - name: Post Build | Prepare artifacts [Windows]
-        if: matrix.os == 'windows-latest'
+        if: startsWith(matrix.os,  'windows-')
         run: |
           cd target/${{ matrix.target }}/release
           dir
@@ -142,14 +142,14 @@ jobs:
           7z a ../../../zinniad-${{ matrix.name }} zinniad.exe golassie.dll
 
       - name: Post Build | Prepare artifacts [Linux]
-        if: matrix.os == 'ubuntu-latest'
+        if: startsWith(matrix.os,  'ubuntu-')
         run: |
           cd target/${{ matrix.target }}/release
           tar czvf ../../../zinnia-${{ matrix.name }} zinnia
           tar czvf ../../../zinniad-${{ matrix.name }} zinniad
 
       - name: Post Build | Sign the executables [macOS]
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os,  'macos-')
         env:
           LOCAL_KEYCHAIN_PASSWORD: ${{ secrets.LOCAL_KEYCHAIN_PASSWORD }}
           MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
@@ -176,14 +176,14 @@ jobs:
             target/${{ matrix.target }}/release/zinniad
 
       - name: Post Build | Prepare artifacts [macOS]
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os,  'macos-')
         run: |
           cd target/${{ matrix.target }}/release
           zip ../../../zinnia-${{ matrix.name }} zinnia
           zip ../../../zinniad-${{ matrix.name }} zinniad
 
       - name: Post Build | Notarize the executables [macOS]
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os,  'macos-')
         run: |
           xcrun notarytool submit zinnia-${{ matrix.name }} --wait \
             --apple-id ${{ secrets.APPLE_ID }} \


### PR DESCRIPTION
Rework all `if` conditions in workflow steps from checking the exact string equality (e.g. `matrix.os == 'macos-latest'`) to checking only the platform prefix (e.g. `startsWith(matrix.os,  'macos-')`).

This fixes the regression introduced by eb98870 (#490), see https://github.com/filecoin-station/zinnia/actions/runs/8718338987
