### PR TITLE
fix: pubkey-like value for `stationId` in dev/test

### DIFF
--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -179,7 +179,7 @@ mod tests {
             cache_root: temp.join("cache").to_string_lossy().into(),
             state_root: temp.join("state").to_string_lossy().into(),
             wallet_address: "f1test".to_string(),
-            station_id: "zinnia-dev".to_string(),
+            station_id: "a".repeat(64),
             files: vec![mod_js.path().to_string_lossy().to_string()],
         };
         let RunOutput { lassie_daemon, .. } = run(args).await.expect("cannot run dummy.js");

--- a/daemon/tests/daemon_tests.rs
+++ b/daemon/tests/daemon_tests.rs
@@ -26,7 +26,7 @@ pub fn it_removes_lassie_temp_on_start() {
     let mut cmd = Command::new(bin);
     cmd.env("NO_COLOR", "1")
         .env("FIL_WALLET_ADDRESS", "f1test")
-        .env("STATION_ID", "zinnia-dev")
+        .env("STATION_ID", "a".repeat(64))
         .env("CACHE_ROOT", cache_root.display().to_string())
         .env("STATE_ROOT", state_root.display().to_string())
         .args([&mod_js.as_os_str()])

--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -305,6 +305,8 @@ for await (const chunk of response) {
 
 The associated Station Core's unique identifier (public key)
 
+The value is hard-coded to 64 `0` characters when running the module via `zinnia` CLI.
+
 #### `Zinnia.walletAddress`
 
 The wallet address where to send rewards. When running inside the Station Desktop, this API will

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -65,7 +65,10 @@ impl BootstrapOptions {
             module_root,
             // See https://lotus.filecoin.io/lotus/manage/manage-fil/#public-key-address
             wallet_address: String::from("t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za"),
-            station_id: String::from("zinnia-dev"),
+            // Station ID must look like a public key - 64 hexadecimal characters.
+            // Let's use all-zeroes value to make it easy to distinguish data reported
+            // from non-production systems (dev, CI).
+            station_id: "0".repeat(64),
             reporter,
             lassie_daemon,
             zinnia_version: env!("CARGO_PKG_VERSION"),

--- a/runtime/tests/js/station_apis_tests.js
+++ b/runtime/tests/js/station_apis_tests.js
@@ -9,5 +9,5 @@ test("Zinnia.walletAddress", () => {
 });
 
 test("Zinnia.stationId", () => {
-  assertStrictEquals(Zinnia.stationId, "zinnia-dev");
+  assertStrictEquals(Zinnia.stationId, "0".repeat(64));
 });


### PR DESCRIPTION
Modify `zinnia` and our test files to set `stationId` value to string of 64 hexadecimal characters, to make it look like a valid public key produced by Station Core.

Links:
- https://github.com/filecoin-station/spark-api/pull/249
- https://github.com/filecoin-station/roadmap/issues/97
