### PR TITLE
fix: change the hard-coded station id to 88 chars

### DIFF
--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -179,7 +179,7 @@ mod tests {
             cache_root: temp.join("cache").to_string_lossy().into(),
             state_root: temp.join("state").to_string_lossy().into(),
             wallet_address: "f1test".to_string(),
-            station_id: "a".repeat(64),
+            station_id: "a".repeat(88),
             files: vec![mod_js.path().to_string_lossy().to_string()],
         };
         let RunOutput { lassie_daemon, .. } = run(args).await.expect("cannot run dummy.js");

--- a/daemon/tests/daemon_tests.rs
+++ b/daemon/tests/daemon_tests.rs
@@ -26,7 +26,7 @@ pub fn it_removes_lassie_temp_on_start() {
     let mut cmd = Command::new(bin);
     cmd.env("NO_COLOR", "1")
         .env("FIL_WALLET_ADDRESS", "f1test")
-        .env("STATION_ID", "a".repeat(64))
+        .env("STATION_ID", "a".repeat(88))
         .env("CACHE_ROOT", cache_root.display().to_string())
         .env("STATE_ROOT", state_root.display().to_string())
         .args([&mod_js.as_os_str()])

--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -305,7 +305,7 @@ for await (const chunk of response) {
 
 The associated Station Core's unique identifier (public key)
 
-The value is hard-coded to 64 `0` characters when running the module via `zinnia` CLI.
+The value is hard-coded to 88 `0` characters when running the module via `zinnia` CLI.
 
 #### `Zinnia.walletAddress`
 

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -65,10 +65,10 @@ impl BootstrapOptions {
             module_root,
             // See https://lotus.filecoin.io/lotus/manage/manage-fil/#public-key-address
             wallet_address: String::from("t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za"),
-            // Station ID must look like a public key - 64 hexadecimal characters.
+            // Station ID must look like a public key - 88 hexadecimal characters.
             // Let's use all-zeroes value to make it easy to distinguish data reported
             // from non-production systems (dev, CI).
-            station_id: "0".repeat(64),
+            station_id: "0".repeat(88),
             reporter,
             lassie_daemon,
             zinnia_version: env!("CARGO_PKG_VERSION"),

--- a/runtime/tests/js/station_apis_tests.js
+++ b/runtime/tests/js/station_apis_tests.js
@@ -9,5 +9,5 @@ test("Zinnia.walletAddress", () => {
 });
 
 test("Zinnia.stationId", () => {
-  assertStrictEquals(Zinnia.stationId, "0".repeat(64));
+  assertStrictEquals(Zinnia.stationId, "0".repeat(88));
 });


### PR DESCRIPTION
An ED25519 public key exported in the SPKI format has always 44 bytes, that is 88 characters in hexadecimal encoding.

This is a follow-up for:
- #529
