### PR TITLE
fix: use `0x00(...)0DEaD` as the dev wallet

### DIFF
--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -310,10 +310,10 @@ The value is hard-coded to 88 `0` characters when running the module via `zinnia
 #### `Zinnia.walletAddress`
 
 The wallet address where to send rewards. When running inside the Station Desktop, this API will
-return the address of Station's built-in wallet.
+return the address of the Station's built-in wallet.
 
-The value is hard-coded to a testnet address `t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za` when
-running the module via `zinnia` CLI.
+The value is hard-coded to the Ethereum (FEVM) address `0x000000000000000000000000000000000000dEaD`
+when running the module via `zinnia` CLI.
 
 #### `Zinnia.activity.info(message)`
 

--- a/runtime/runtime.rs
+++ b/runtime/runtime.rs
@@ -63,8 +63,7 @@ impl BootstrapOptions {
             agent_version,
             rng_seed: None,
             module_root,
-            // See https://lotus.filecoin.io/lotus/manage/manage-fil/#public-key-address
-            wallet_address: String::from("t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za"),
+            wallet_address: String::from("0x000000000000000000000000000000000000dEaD"),
             // Station ID must look like a public key - 88 hexadecimal characters.
             // Let's use all-zeroes value to make it easy to distinguish data reported
             // from non-production systems (dev, CI).

--- a/runtime/tests/js/station_apis_tests.js
+++ b/runtime/tests/js/station_apis_tests.js
@@ -5,7 +5,7 @@ test("Zinnia.walletAddress", () => {
   // Runtime JS tests are executed with the default configuration
   // In this test, we assert that we can access the wallet address
   // and the value is the default testnet one.
-  assertStrictEquals(Zinnia.walletAddress, "t1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za");
+  assertStrictEquals(Zinnia.walletAddress, "0x000000000000000000000000000000000000dEaD");
 });
 
 test("Zinnia.stationId", () => {


### PR DESCRIPTION
Fix Spark Checker CI builds - e.g. here: https://github.com/filecoin-station/spark/actions/runs/9063057104/job/24898210891

See also:
- https://github.com/filecoin-station/spark-api/pull/258