### PR TITLE
ci: pin Rust version to 1.77

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # v1
         with:
-          toolchain: stable
+          toolchain: 1.77
           target: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
@@ -76,7 +76,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # v1
         with:
-          toolchain: stable
+          toolchain: 1.77
           target: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
@@ -117,7 +117,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # v1
         with:
-          toolchain: stable
+          toolchain: 1.77
 
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
         with:
@@ -135,7 +135,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # v1
         with:
-          toolchain: stable
+          toolchain: 1.77
           components: clippy
 
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
@@ -159,7 +159,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # v1
         with:
-          toolchain: stable
+          toolchain: 1.77
           components: rustfmt
 
       - name: Check formatting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Setup | Rust
         uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # v1
         with:
-          toolchain: stable
+          toolchain: 1.77
           target: ${{ matrix.target }}
 
       - name: Setup | Cross


### PR DESCRIPTION
Our release binaries are crashing when built by Rust 1.78.

Suspected cause: Rust 1.78 upgraded LLVM from v17 to v18, perhaps our ancient Deno version is not compatible with that.
