### PR TITLE
fix: report canonicalized module path

### DIFF
--- a/runtime/tests/js/module_loader_tests.js
+++ b/runtime/tests/js/module_loader_tests.js
@@ -18,5 +18,5 @@ test("can import files outside the main module directory", async () => {
 
 test("cannot import files over http", async () => {
   let err = await assertRejects(() => import("https://deno.land/std@0.181.0/version.ts"));
-  assertMatch(err.message, /Zinnia supports importing from relative paths only/);
+  assertMatch(err.message, /Zinnia can import local modules only/);
 });


### PR DESCRIPTION
In 31c029238 (#557), I improved the error message printed when the module is outside of the root dir to include the file path of the imported module. That's not enough to troubleshoot the problem, because we print the non-canonical path, which is potentially different from the string we use to check if the module path is within the root dir.

In this commit, I refactored the method to make the code easier to follow, and improved the error message to print the canonicalized paths of the module and the root dir.

Links:
- https://github.com/filecoin-station/zinnia/issues/485
