### PR TITLE
fix: object diff when assertion failed

### DIFF
--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -389,6 +389,12 @@ const response = await fetch(requestUrl, {
 
 ### Miscelaneous APIs
 
+#### `Zinnia.inspect`
+
+Converts the input into a string that has the same format as printed by `console.log()`.
+
+See [Deno.inspect() docs](https://docs.deno.com/api/deno/~/Deno.inspect) for more details.
+
 #### `Zinnia.versions.zinna`
 
 The version of Zinnia runtime, e.g. `"0.11.0"`.

--- a/runtime/js/90_zinnia_apis.js
+++ b/runtime/js/90_zinnia_apis.js
@@ -5,6 +5,7 @@ const { ops } = globalThis.Deno.core;
 
 import { readOnly } from "ext:zinnia_runtime/06_util.js";
 import * as libp2p from "ext:zinnia_libp2p/01_peer.js";
+import { inspect } from "ext:deno_console/01_console.js";
 
 const versions = {
   zinnia: "",
@@ -31,6 +32,7 @@ ObjectDefineProperties(zinniaNs, {
   activity: readOnly(activityApi),
   jobCompleted: readOnly(reportJobCompleted),
   versions: readOnly(versions),
+  inspect: readOnly(inspect),
 });
 
 function reportInfoActivity(msg) {

--- a/runtime/js/vendored/asserts.bundle.js
+++ b/runtime/js/vendored/asserts.bundle.js
@@ -112,7 +112,7 @@ function equal(c, d) {
 }
 export { equal as equal };
 function format(v) {
-    const { Deno } = globalThis;
+    const { Zinnia: Deno } = globalThis;
     return typeof Deno?.inspect === "function" ? Deno.inspect(v, {
         depth: Infinity,
         sorted: true,
@@ -145,7 +145,7 @@ function assertArrayIncludes(actual, expected, msg) {
     throw new AssertionError(msg);
 }
 export { assertArrayIncludes as assertArrayIncludes };
-const { Deno } = globalThis;
+const { Zinnia: Deno } = globalThis;
 const noColor = false;
 const enabled = !noColor;
 function code(open, close) {

--- a/runtime/vendor.js
+++ b/runtime/vendor.js
@@ -29,11 +29,17 @@ async function vendor(url, outfile) {
 }
 
 async function patchAssertsBundle(assertsPath) {
-  return patchFile(assertsPath, (content) =>
-    content.replace(
-      'const noColor = typeof Deno?.noColor === "boolean" ? Deno.noColor : false;',
-      "const noColor = false;",
-    ),
+  await patchFile(assertsPath, (content) =>
+    content
+      .replace(
+        'const noColor = typeof Deno?.noColor === "boolean" ? Deno.noColor : false;',
+        "const noColor = false;",
+      )
+      .replaceAll(
+        "const { Deno } = globalThis;",
+        // Deno.inspect is exposed via Zinnia.inspect
+        "const { Zinnia: Deno } = globalThis;",
+      ),
   );
 }
 


### PR DESCRIPTION
Expose `Deno.inspect` as `Zinnia.inspect`.

Fix the error message printed by assertion functions to describe object properties.

Before this fix:

```
error: Uncaught AssertionError: Values are not equal.

    [Diff] Actual / Expected

    "[object Object]"

    at assertEquals (ext:zinnia_runtime/vendored/asserts.bundle.js:479:11)
```

After the fix:

```
error: Uncaught AssertionError: Values are not equal.

    [Diff] Actual / Expected

    {
-     foo: "bar",
+     foo: "123",
    }

    at assertEquals (ext:zinnia_runtime/vendored/asserts.bundle.js:495:11)
```

I noticed the problem while working on https://github.com/filecoin-station/spark/issues/46
