### PR TITLE
test: fix "it_removes_lassie_temp_on_start"

### DIFF
--- a/daemon/tests/fixtures/fetch-ipfs-with-delay.js
+++ b/daemon/tests/fixtures/fetch-ipfs-with-delay.js
@@ -1,6 +1,6 @@
 // Signal that we are going to start the retrieval
 Zinnia.activity.info("fetch:start");
-const response = await fetch("ipfs://QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm");
+const response = await fetch("ipfs://bafybeiazvkej6ou3w6xmva5ed6suonxjv3jkhq4ke73q5hgmcjmf76uos4");
 
 Zinnia.activity.info("fetch:response-headers");
 


### PR DESCRIPTION
A bunch of Dependabot PRs are blocked from landing because of this test
failing.

In this PR, I am fixing the test by changing the CID we are downloading.

I am also adding more diagnostics to simplify troubleshooting in the future.

Here is how to run this single test and get the additional info:

```
cargo test --test daemon_tests -- --nocapture
```
